### PR TITLE
Use the same Infinispan version everywhere

### DIFF
--- a/infinispan/runtime/pom.xml
+++ b/infinispan/runtime/pom.xml
@@ -24,7 +24,6 @@
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-core</artifactId>
-      <version>${version.infinispan}</version>
       <exclusions>
         <exclusion>
           <groupId>org.jboss.spec.javax.transaction</groupId>
@@ -39,17 +38,14 @@
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-commons</artifactId>
-      <version>${version.infinispan}</version>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-server-core</artifactId>
-      <version>${version.infinispan}</version>
     </dependency>
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-server-hotrod</artifactId>
-      <version>${version.infinispan}</version>
     </dependency>
   </dependencies>
 

--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
     <artifactId>cache-manager</artifactId>
+    <name>Gingersnap Cache Manager:: Cache Manager</name>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,27 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <!-- overwrite Infinispan version otherwise version from quarkus-bom is used -->
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-core</artifactId>
+        <version>${version.infinispan}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-commons</artifactId>
+        <version>${version.infinispan}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-server-hotrod</artifactId>
+        <version>${version.infinispan}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-server-core</artifactId>
+        <version>${version.infinispan}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Different versions of Infinispan are used when compiling the project. The PR fixes it by using the same versions everywhere.

From the main branch, we have the following output:

```bash
$ mvn dependency:list -Dincludes=org.infinispan | grep org.infinispan | sort -u
[INFO]    org.infinispan:infinispan-clustered-counter:jar:14.0.1.Final:compile
[INFO]    org.infinispan:infinispan-clustered-counter:jar:14.0.2.Final:compile
[INFO]    org.infinispan:infinispan-commons:jar:14.0.1.Final:compile
[INFO]    org.infinispan:infinispan-commons:jar:14.0.2.Final:compile
[INFO]    org.infinispan:infinispan-core:jar:14.0.1.Final:compile
[INFO]    org.infinispan:infinispan-core:jar:14.0.2.Final:compile
[INFO]    org.infinispan:infinispan-multimap:jar:14.0.1.Final:compile
[INFO]    org.infinispan:infinispan-multimap:jar:14.0.2.Final:compile
[INFO]    org.infinispan:infinispan-server-core:jar:14.0.2.Final:compile
[INFO]    org.infinispan:infinispan-server-hotrod:jar:14.0.1.Final:compile
[INFO]    org.infinispan:infinispan-server-hotrod:jar:14.0.2.Final:compile
[INFO]    org.infinispan:infinispan-tasks-api:jar:14.0.2.Final:compile
[INFO]    org.infinispan:infinispan-tasks:jar:14.0.2.Final:compile
```