### PR TITLE
Expose metrics for cache access

### DIFF
--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -57,7 +57,16 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -69,6 +78,16 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>elasticsearch</artifactId>
             <version>${version.elasticsearch.container}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/manager/src/main/java/io/gingersnapproject/metrics/CacheAccessRecord.java
+++ b/manager/src/main/java/io/gingersnapproject/metrics/CacheAccessRecord.java
@@ -1,0 +1,21 @@
+package io.gingersnapproject.metrics;
+
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+
+/**
+ * Records cache access latency.
+ * <p>
+ * This interface extends {@link BiConsumer} allowing to use with {@link CompletionStage#whenComplete(BiConsumer)}
+ * methods.
+ * <p>
+ * Exceptions are not an expected outcome and they are recorded as errors. A {@code null} value means a cache miss.
+ */
+public interface CacheAccessRecord<T> extends BiConsumer<T, Throwable> {
+
+    default void recordThrowable(Throwable throwable) {
+        accept(null, throwable);
+    }
+
+    void localHit(boolean localHit);
+}

--- a/manager/src/main/java/io/gingersnapproject/metrics/CacheManagerMetrics.java
+++ b/manager/src/main/java/io/gingersnapproject/metrics/CacheManagerMetrics.java
@@ -1,0 +1,18 @@
+package io.gingersnapproject.metrics;
+
+/**
+ * Entry point to collect metrics.
+ */
+public interface CacheManagerMetrics {
+
+   /**
+    * Records a cache access.
+    * <p>
+    * The {@link CacheAccessRecord} must be used to record a single invocation.
+    *
+    * @param <T> The value's type.
+    * @return A {@link CacheAccessRecord} instance.
+    */
+   <T> CacheAccessRecord<T> recordCacheAccess();
+
+}

--- a/manager/src/main/java/io/gingersnapproject/metrics/micrometer/CacheManagerMetricsProducer.java
+++ b/manager/src/main/java/io/gingersnapproject/metrics/micrometer/CacheManagerMetricsProducer.java
@@ -1,0 +1,28 @@
+package io.gingersnapproject.metrics.micrometer;
+
+import io.gingersnapproject.metrics.CacheManagerMetrics;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+/**
+ * Produces a {@link CacheManagerMetrics} implementation.
+ * <p>
+ * Current implementation uses MicroMeter to store and report metrics information.
+ */
+@ApplicationScoped
+public class CacheManagerMetricsProducer {
+
+   private final CacheManagerMetrics metrics;
+
+   public CacheManagerMetricsProducer(MeterRegistry registry) {
+      metrics = new CacheManagerMicrometerMetrics(registry);
+   }
+
+   @Produces
+   public CacheManagerMetrics cacheManagerMetrics() {
+      return metrics;
+   }
+
+}

--- a/manager/src/main/java/io/gingersnapproject/metrics/micrometer/CacheManagerMicrometerMetrics.java
+++ b/manager/src/main/java/io/gingersnapproject/metrics/micrometer/CacheManagerMicrometerMetrics.java
@@ -1,0 +1,80 @@
+package io.gingersnapproject.metrics.micrometer;
+
+import java.time.Duration;
+import java.util.EnumMap;
+import java.util.concurrent.TimeUnit;
+
+import io.gingersnapproject.metrics.CacheAccessRecord;
+import io.gingersnapproject.metrics.CacheManagerMetrics;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * A {@link CacheManagerMetrics} implementation that uses {@link MeterRegistry} to store metrics information.
+ */
+public class CacheManagerMicrometerMetrics implements CacheManagerMetrics {
+
+    private final EnumMap<TimerMetric, Timer> timers = new EnumMap<>(TimerMetric.class);
+
+    private static Timer createTimer(MeterRegistry registry, String mame, String description) {
+        return Timer.builder(mame)
+                .description(description)
+                .tags("gingersnap", "cache_manager")
+                .publishPercentileHistogram()
+                // TODO keep or allow to be configured?
+                // pre-defined histogram bucket so we can see the number of request with latency <= the values below
+                .serviceLevelObjectives(
+                        Duration.ofMillis(1),
+                        Duration.ofMillis(5),
+                        Duration.ofMillis(10),
+                        Duration.ofMillis(50),
+                        Duration.ofMillis(100),
+                        Duration.ofMillis(500))
+                // TODO keep or configure?
+                // By default, micromenter creates a tons of bucket with values > 1second. We don't need them.
+                .maximumExpectedValue(Duration.ofSeconds(1))
+                .register(registry);
+    }
+
+    public CacheManagerMicrometerMetrics(MeterRegistry registry) {
+        for (TimerMetric metric : TimerMetric.values()) {
+            timers.put(metric, createTimer(registry, metric.metricName(), metric.description()));
+        }
+    }
+
+    @Override
+    public <T> CacheAccessRecord<T> recordCacheAccess() {
+        return new CacheAccessRecordImpl<>(System.nanoTime());
+    }
+
+    private class CacheAccessRecordImpl<T> implements CacheAccessRecord<T> {
+
+        private final long startTimeNanos;
+        private volatile boolean localHit = true;
+
+        private CacheAccessRecordImpl(long startTimeNanos) {
+            this.startTimeNanos = startTimeNanos;
+        }
+
+        @Override
+        public void accept(T value, Throwable throwable) {
+            if (value != null) {
+                // most common use case first
+                recordLatency(localHit ? TimerMetric.CACHE_LOCAL_HIT : TimerMetric.CACHE_REMOTE_HIT);
+            } else if (throwable != null) {
+                recordLatency(TimerMetric.CACHE_ERROR);
+            } else {
+                recordLatency(localHit ? TimerMetric.CACHE_LOCAL_MISS : TimerMetric.CACHE_REMOTE_MISS);
+            }
+        }
+
+        @Override
+        public void localHit(boolean localHit) {
+            this.localHit = localHit;
+        }
+
+        private void recordLatency(TimerMetric metric) {
+            timers.get(metric).record(System.nanoTime() - startTimeNanos, TimeUnit.NANOSECONDS);
+        }
+    }
+}

--- a/manager/src/main/java/io/gingersnapproject/metrics/micrometer/TimerMetric.java
+++ b/manager/src/main/java/io/gingersnapproject/metrics/micrometer/TimerMetric.java
@@ -1,0 +1,25 @@
+package io.gingersnapproject.metrics.micrometer;
+
+public enum TimerMetric {
+    CACHE_LOCAL_HIT("cache_local_hit", "Gingersnap cache hits latency when the value is found locally"),
+    CACHE_LOCAL_MISS("cache_local_miss", "Gingersnap cache miss latency when a tombstone is found locally"),
+    CACHE_REMOTE_HIT("cache_hit_with_database", "Gingersnap cache hits latency when the value is fetched from the database"),
+    CACHE_REMOTE_MISS("cache_miss_with_database", "Gingersnap cache miss latency when the value is not found in the database"),
+    CACHE_ERROR("cache_error", "Gingersnap error latency");
+
+    private final String metricName;
+    private final String description;
+
+    TimerMetric(String metricName, String description) {
+        this.metricName = metricName;
+        this.description = description;
+    }
+
+    public String metricName() {
+        return metricName;
+    }
+
+    public String description() {
+        return description;
+    }
+}

--- a/manager/src/test/java/io/gingersnapproject/metrics/MetricsResourceTest.java
+++ b/manager/src/test/java/io/gingersnapproject/metrics/MetricsResourceTest.java
@@ -1,0 +1,81 @@
+package io.gingersnapproject.metrics;
+
+import io.gingersnapproject.metrics.micrometer.TimerMetric;
+import io.gingersnapproject.mysql.MySQLResources;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.apache.http.HttpStatus;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static java.lang.String.format;
+import static org.hamcrest.CoreMatchers.containsString;
+
+@QuarkusTest
+@QuarkusTestResource(MySQLResources.class)
+public class MetricsResourceTest {
+
+    private static final String GET_PATH = "/rules/{rule}/{key}";
+    private static final String METRIC_FORMAT = "%s_seconds_count{gingersnap=\"cache_manager\",} %s";
+
+    @Test
+    public void testMetricsEndpoint() {
+        EnumMap<TimerMetric, String> expectedCount = new EnumMap<>(TimerMetric.class);
+        Arrays.stream(TimerMetric.values()).forEach(metric -> expectedCount.put(metric, "0.0"));
+
+        // cache remote hit!
+        given()
+                .when().get(GET_PATH, "us-east", "1")
+                .then().body(containsString("Jon Doe"));
+        expectedCount.put(TimerMetric.CACHE_REMOTE_HIT, "1.0");
+        assertMetricsValue(expectedCount);
+
+        // cache local hit
+        given()
+                .when().get(GET_PATH, "us-east", "1")
+                .then().body(containsString("Jon Doe"));
+        expectedCount.put(TimerMetric.CACHE_LOCAL_HIT, "1.0");
+        assertMetricsValue(expectedCount);
+
+        // cache remote miss
+        given()
+                .when().get(GET_PATH, "us-east", "100000")
+                .then().statusCode(HttpStatus.SC_NO_CONTENT);
+        expectedCount.put(TimerMetric.CACHE_REMOTE_MISS, "1.0");
+        assertMetricsValue(expectedCount);
+
+        // cache local miss
+        given()
+                .when().get(GET_PATH, "us-east", "100000")
+                .then().statusCode(HttpStatus.SC_NO_CONTENT);
+        expectedCount.put(TimerMetric.CACHE_LOCAL_MISS, "1.0");
+        assertMetricsValue(expectedCount);
+
+        // cache error
+        given()
+                .when().get(GET_PATH, "non-existing-rule", "100000")
+                .then().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        expectedCount.put(TimerMetric.CACHE_ERROR, "1.0");
+        assertMetricsValue(expectedCount);
+    }
+
+    private void assertMetricsValue(EnumMap<TimerMetric, String> expectedCount) {
+        var matcherList = expectedCount.entrySet().stream()
+                .map(MetricsResourceTest::convertToContainsString)
+                .toList();
+        given()
+                .get("/q/metrics")
+                .then()
+                .body(matcherList.get(0), matcherList.subList(1, matcherList.size()).toArray(Matcher[]::new));
+    }
+
+    private static Matcher<String> convertToContainsString(Map.Entry<TimerMetric, String> entry) {
+        return containsString(format(METRIC_FORMAT, entry.getKey().metricName(), entry.getValue()));
+    }
+
+}

--- a/manager/src/test/java/io/gingersnapproject/mysql/MySQLResources.java
+++ b/manager/src/test/java/io/gingersnapproject/mysql/MySQLResources.java
@@ -1,0 +1,43 @@
+package io.gingersnapproject.mysql;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.utility.MountableFile;
+
+import java.util.Map;
+
+public class MySQLResources implements QuarkusTestResourceLifecycleManager {
+
+    private static final String IMAGE = "mysql:8.0.31";
+    private MySQLContainer<?> db;
+
+    @Override
+    public Map<String, String> start() {
+
+
+        db = new MySQLContainer<>(IMAGE)
+                .withUsername("gingersnap_user")
+                .withPassword("password")
+                .withExposedPorts(MySQLContainer.MYSQL_PORT)
+                .withCopyFileToContainer(MountableFile.forClasspathResource("setup.sql"), "/docker-entrypoint-initdb.d/setup.sql");
+        db.start();
+
+        return Map.of(
+                "quarkus.datasource.db-kind", "MYSQL",
+                "quarkus.datasource.username", db.getUsername(),
+                "quarkus.datasource.password", db.getPassword(),
+                "quarkus.datasource.reactive.url", String.format("mysql://%s:%d/debezium", db.getHost(), db.getMappedPort(MySQLContainer.MYSQL_PORT)),
+                "gingersnap.rule.us-east.key-type", "PLAIN",
+                "gingersnap.rule.us-east.plain-separator", ":",
+                "gingersnap.rule.us-east.select-statement", "select fullname, email from customer where id = ?",
+                "gingersnap.rule.us-east.connector.schema", "debezium",
+                "gingersnap.rule.us-east.connector.table", "customer"
+        );
+    }
+
+    @Override
+    public void stop() {
+        if (db != null)
+            db.stop();
+    }
+}

--- a/manager/src/test/resources/setup.sql
+++ b/manager/src/test/resources/setup.sql
@@ -1,0 +1,12 @@
+create schema debezium;
+create table debezium.customer(id int not null, fullname varchar(255), email varchar(255), constraint primary key (id));
+create table debezium.car_model(id int not null, model varchar(255), brand varchar(255), constraint primary key (id));
+GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'gingersnap_user';
+
+insert into debezium.customer values (1, 'Jon Doe', 'jd@example.com');
+insert into debezium.customer values (3, 'Bob', 'bob@example.com');
+insert into debezium.customer values (4, 'Alice', 'alice@example.com');
+insert into debezium.customer values (5, 'Mallory', 'mallory@example.com');
+
+insert into debezium.car_model values (1, 'QQ', 'Chery');
+insert into debezium.car_model values (2, 'Beetle', 'VW');


### PR DESCRIPTION
Histogram for cache hits, misses and errors are exposed.


Dev notes:
I decided to create an abstraction instead of using the MicroMeter interfaces directly in case Quarkus changes MicroMeter with something else. If someone thinks that it is overkill, I can remove the abstraction.

Used histogram to expose the access latency instead of averages since it gives us more fine-grained information. Min/Max is not exposed in the Histogram but, if it is useful, I can add new metrics for them.

The histogram exposes the following information in `/metrics` endpoint:

`<metric>_count`: total number of requests
`<metric>_sum`: the sum of all latencies
`<metric>_bucket{"value"}`: number of requests with latency less or equal to `value`.

Average latency can be shown in Graphana/Prometheus with `<metric>_sum/<metric>_count`

Average latency in the last `X` minutes can be shown in Graphana with `rate(<metric>_sum[Xm])/rate(<metric>_count[Xm])`