### PR TITLE
Add in DB lazy load support

### DIFF
--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -41,6 +41,14 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-kubernetes-service-binding</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-reactive-mysql-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-resteasy-reactive</artifactId>
         </dependency>
         <dependency>

--- a/manager/src/main/java/io/gingersnapproject/Caches.java
+++ b/manager/src/main/java/io/gingersnapproject/Caches.java
@@ -5,40 +5,92 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Stream;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
-
-import org.infinispan.commons.marshall.WrappedByteArray;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
+import io.gingersnapproject.database.DatabaseHandler;
+import io.gingersnapproject.mutiny.UniItem;
+import io.smallrye.mutiny.Uni;
 
 @Singleton
 public class Caches {
-   private final ConcurrentMap<String, Cache<String, WrappedByteArray>> maps = new ConcurrentHashMap<>();
+   private final ConcurrentMap<String, LoadingCache<String, Uni<String>>> maps = new ConcurrentHashMap<>();
    private final ConcurrentMap<String, Cache<String, List<byte[]>>> multiMaps = new ConcurrentHashMap<>();
 
-   private Cache<String, WrappedByteArray> getOrCreateMap(String name) {
-      // TODO: eventually need to apply eviction to this. Can use a weigher to count byte[] size per key/value
-      return maps.computeIfAbsent(name, ___ -> Caffeine.newBuilder().build());
+   @Inject
+   DatabaseHandler databaseHandler;
+
+   public ConcurrentMap<String, Cache<String, List<byte[]>>> getMultiMaps() {
+      return multiMaps;
    }
 
-   public byte[] get(String name, String key) {
-      WrappedByteArray value = getOrCreateMap(name).getIfPresent(key);
-      return value == null ? null : value.getBytes();
+   private LoadingCache<String, Uni<String>> getOrCreateMap(String name) {
+      return maps.computeIfAbsent(name, ___ -> Caffeine.newBuilder()
+            // TODO: populate this with config
+            .maximumWeight(1_000_000)
+            .<String, Uni<String>>weigher((k, v) -> {
+               // TODO: need to revisit this later
+               int size = k.length() * 2 + 1;
+               if (v instanceof UniItem<String> uniItem) {
+                  var actualValue = uniItem.getItem();
+                  size += actualValue == null ? 0 : actualValue.length() * 2 + 1;
+                  if (size < 0) {
+                     size = Integer.MAX_VALUE;
+                  }
+               }
+               return size;
+            })
+            .build(key -> {
+               Uni<String> dbUni = databaseHandler.select(name, key)
+                     // Make sure to use memoize, so that if multiple people subscribe to this it won't cause
+                     // multiple DB lookups
+                     .memoize().indefinitely();
+               // This will replace the pending Uni from the DB with a UniItem so we can properly size the entry
+               // Note due to how lazy subscribe works the entry won't be present in the map  yet
+               dbUni.subscribe()
+                     .with(result -> replace(name, key, dbUni, result), t -> actualRemove(name, key, dbUni));
+               return dbUni;
+            }));
+   }
+
+   private void replace(String name, String key, Uni<String> prev, String value) {
+      var cache = maps.get(name);
+      if (cache != null) {
+         cache.asMap().replace(key, prev, UniItem.fromItem(value));
+      }
+   }
+
+   private void actualRemove(String name, String key, Uni<String> value) {
+      var cache = maps.get(name);
+      if (cache != null) {
+         cache.asMap().remove(key, value);
+      }
+   }
+
+   public void put(String name, String key, String value) {
+      getOrCreateMap(name)
+            .put(key, UniItem.fromItem(value));
+   }
+
+   public Uni<String> get(String name, String key) {
+      return getOrCreateMap(name).get(key);
    }
 
    public Stream<String> getKeys(String name) {
-      Cache<String, WrappedByteArray> cache = getOrCreateMap(name);
+      Cache<String, ?> cache = getOrCreateMap(name);
       return cache.asMap()
             .keySet()
             .stream();
    }
 
-   public ConcurrentMap<String, Cache<String, WrappedByteArray>> getMaps() {
-      return maps;
-   }
-
-   public ConcurrentMap<String, Cache<String, List<byte[]>>> getMultiMaps() {
-      return multiMaps;
+   public boolean remove(String name, String key) {
+      // TODO: technically this says it removed something even if the Uni contained a null value prior
+      // We put a null uni into the map if a value existed before. This way we cache the tombstone.
+      return getOrCreateMap(name).asMap()
+            .replace(key, Uni.createFrom().nullItem()) != null;
    }
 }

--- a/manager/src/main/java/io/gingersnapproject/RuleResource.java
+++ b/manager/src/main/java/io/gingersnapproject/RuleResource.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 
 import io.smallrye.mutiny.Multi;
+import io.smallrye.mutiny.Uni;
 
 @Path("/rules")
 public class RuleResource {
@@ -20,9 +21,8 @@ public class RuleResource {
    @Operation(summary = "Retrieve a cache entry associated with the provided rule and key")
    @Path("/{rule}/{key}")
    @Produces(MediaType.APPLICATION_JSON)
-   public String get(String rule, String key) {
-      byte[] value = maps.get(rule, key);
-      return value == null ? null : new String(value);
+   public Uni<String> get(String rule, String key) {
+      return maps.get(rule, key);
    }
 
    @GET

--- a/manager/src/main/java/io/gingersnapproject/configuration/Configuration.java
+++ b/manager/src/main/java/io/gingersnapproject/configuration/Configuration.java
@@ -1,8 +1,14 @@
 package io.gingersnapproject.configuration;
 
+import java.util.Map;
+
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithName;
 
 @ConfigMapping(prefix = "gingersnap")
 public interface Configuration {
    HotRod hotrod();
+
+   @WithName("rule")
+   Map<String, Rule> rules();
 }

--- a/manager/src/main/java/io/gingersnapproject/configuration/Connector.java
+++ b/manager/src/main/java/io/gingersnapproject/configuration/Connector.java
@@ -1,0 +1,11 @@
+package io.gingersnapproject.configuration;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+
+@ConfigGroup
+public interface Connector {
+
+   String schema();
+
+   String table();
+}

--- a/manager/src/main/java/io/gingersnapproject/configuration/Rule.java
+++ b/manager/src/main/java/io/gingersnapproject/configuration/Rule.java
@@ -1,0 +1,39 @@
+package io.gingersnapproject.configuration;
+
+import org.infinispan.commons.dataconversion.internal.Json;
+
+import io.smallrye.config.WithDefault;
+
+public interface Rule {
+
+      Connector connector();
+
+      @WithDefault("PLAIN")
+      KeyType keyType();
+
+      @WithDefault("|")
+      String plainSeparator();
+
+      String selectStatement();
+
+      enum KeyType {
+            PLAIN {
+                  @Override
+                  public String[] toArguments(String strValue, String plainSeparator) {
+                        return strValue.split(plainSeparator);
+                  }
+            },
+            JSON {
+                  @Override
+                  public String[] toArguments(String strValue, String plainSeparator) {
+                        return Json.read(strValue)
+                              .asJsonMap()
+                              .values()
+                              .stream()
+                              .map(Json::toString)
+                              .toArray(String[]::new);
+                  }
+            };
+            public abstract String[] toArguments(String strValue, String plainSeparator);
+      }
+}

--- a/manager/src/main/java/io/gingersnapproject/database/DatabaseHandler.java
+++ b/manager/src/main/java/io/gingersnapproject/database/DatabaseHandler.java
@@ -1,0 +1,61 @@
+package io.gingersnapproject.database;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.infinispan.commons.dataconversion.internal.Json;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.gingersnapproject.configuration.Configuration;
+import io.gingersnapproject.configuration.Rule;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.sqlclient.Tuple;
+import io.vertx.sqlclient.Pool;
+import io.vertx.sqlclient.PreparedQuery;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowIterator;
+import io.vertx.sqlclient.RowSet;
+
+@Singleton
+public class DatabaseHandler {
+   private static final Logger log = LoggerFactory.getLogger(DatabaseHandler.class);
+   @Inject
+   Configuration configuration;
+
+   @Inject
+   Pool pool;
+
+   public Uni<String> select(String rule, String key) {
+      Rule ruleConfig = configuration.rules().get(rule);
+      if (ruleConfig == null) {
+         throw new IllegalArgumentException("No rule found for " + rule);
+      }
+
+      // Have to do this until bug is fixed allowing injection of reactive Pool
+      PreparedQuery<RowSet<Row>> preparedQuery = pool.preparedQuery(ruleConfig.selectStatement());
+      var quarkusPreparedQuery = io.vertx.mutiny.sqlclient.PreparedQuery.<RowSet<Row>>newInstance(preparedQuery);
+
+      String[] arguments = ruleConfig.keyType().toArguments(key, ruleConfig.plainSeparator());
+//      return pool.preparedQuery(ruleConfig.selectStatement())
+      return quarkusPreparedQuery
+            .execute(Tuple.from(arguments))
+            .onFailure().invoke(t -> log.error("Exception encountered!", t))
+            .map(rs -> {
+               if (rs.size() > 1) {
+                  throw new IllegalArgumentException("Result set for " + ruleConfig.selectStatement() + " for key: " + key + " returned " + rs.size() + " rows, it should only return 1");
+               }
+               int columns = rs.columnsNames().size();
+               RowIterator<Row> rowIterator = rs.iterator();
+               if (!rowIterator.hasNext()) {
+                  return null;
+               }
+               Row row = rowIterator.next();
+               Json jsonObject = Json.object();
+               for (int i = 0; i < columns; ++i) {
+                  jsonObject.set(row.getColumnName(i), row.getValue(i));
+               }
+               return jsonObject.toString();
+            });
+   }
+}

--- a/manager/src/main/java/io/gingersnapproject/mutiny/UniItem.java
+++ b/manager/src/main/java/io/gingersnapproject/mutiny/UniItem.java
@@ -1,0 +1,54 @@
+package io.gingersnapproject.mutiny;
+
+import io.smallrye.mutiny.operators.AbstractUni;
+import io.smallrye.mutiny.subscription.UniSubscriber;
+import io.smallrye.mutiny.subscription.UniSubscription;
+
+/**
+ * This class is essentially copied from UniCreateFromKnownItem but exposes the item to allow us to retrieve it
+ * without subscribing
+ * @param <T>
+ */
+public class UniItem<T> extends AbstractUni<T> {
+
+   private final T item;
+
+   private UniItem(T item) {
+      this.item = item;
+   }
+
+   public static <T> UniItem<T> fromItem(T item) {
+      return new UniItem<>(item);
+   }
+
+   public T getItem() {
+      return item;
+   }
+
+   @Override
+   public void subscribe(UniSubscriber<? super T> subscriber) {
+      new KnownItemSubscription(subscriber).forward();
+   }
+
+   private class KnownItemSubscription implements UniSubscription {
+
+      private final UniSubscriber<? super T> subscriber;
+      private volatile boolean cancelled = false;
+
+      private KnownItemSubscription(UniSubscriber<? super T> subscriber) {
+         this.subscriber = subscriber;
+      }
+
+      private void forward() {
+         subscriber.onSubscribe(this);
+         if (!cancelled) {
+            subscriber.onItem(item);
+         }
+      }
+
+      @Override
+      public void cancel() {
+         cancelled = true;
+      }
+   }
+}

--- a/manager/src/main/resources/application.properties
+++ b/manager/src/main/resources/application.properties
@@ -6,4 +6,16 @@ quarkus.smallrye-openapi.info-contact-url=https://gingersnap-project.io
 quarkus.smallrye-openapi.info-license-name=Apache 2.0
 quarkus.smallrye-openapi.info-license-url=https://www.apache.org/licenses/LICENSE-2.0.html
 
+quarkus.datasource.db-kind=MYSQL
+quarkus.datasource.username=gingersnap_user
+quarkus.datasource.password=password
+quarkus.datasource.reactive.url=mysql://localhost:3306/debezium
+
+gingersnap.rule.us-east.key-type=PLAIN
+gingersnap.rule.us-east.plain-separator=:
+gingersnap.rule.us-east.select-statement=select fullname, email from customer where fullname = ?
+
+gingersnap.rule.us-east.connector.schema=debezium
+gingersnap.rule.us-east.connector.table=customer
+
 quarkus.devservices.enabled=false

--- a/manager/src/main/resources/gingersnap.gr
+++ b/manager/src/main/resources/gingersnap.gr
@@ -183,15 +183,12 @@ parameters switch opCode
 // Cache operations
    : { PUT_REQUEST }? key ignoreExpiration value { commandProcessor.put(getHeader(), key, value) }
    | { GET_REQUEST }? key { commandProcessor.get(getHeader(), key) }
-   | { PUT_IF_ABSENT_REQUEST }? key ignoreExpiration value { commandProcessor.putIfAbsent(getHeader(), key, value) }
    | { REMOVE_REQUEST }? key { commandProcessor.remove(getHeader(), key) }
    | { STATS_REQUEST }? { commandProcessor.stats(getHeader()) }
    | { PING_REQUEST }? { commandProcessor.ping(getHeader()); }
    | { QUERY_REQUEST }? queryBytes { commandProcessor.query(getHeader(), queryBytes); }
-   | { SIZE_REQUEST }? { commandProcessor.size(getHeader()); }
    | { EXEC_REQUEST }? taskName taskParams { commandProcessor.exec(getHeader(), taskName, taskParams); }
    | { PUT_ALL_REQUEST }? ignoreExpiration entryMap { commandProcessor.putAll(getHeader(), entryMap) }
-   | { GET_ALL_REQUEST }? keys { commandProcessor.getAll(getHeader(), keys) }
    | { ITERATION_START_REQUEST }? segmentMask filterConverterFactory filterConverterParams batchSize includeMetadata
       { commandProcessor.iterationStart(getHeader(), segmentMask, filterConverterFactory, filterConverterParams, batchSize, includeMetadata); }
    | { ITERATION_NEXT_REQUEST }? iterationId { commandProcessor.iterationNext(getHeader(), iterationId); }


### PR DESCRIPTION
Adds in required DB access that is configurable via application.properties.

Lazily loads the value from the DB if not present. It will cache null values. This change does not include expiration, which will be required for lazy cache only mode (eager does not require this).

Includes basis for weighed eviction where can estimate size based on JVM on heap. Still need to inspect JOL (Java Object Layout) to get these numbers more precise.