### PR TITLE
Disable ElasticSearch health check

### DIFF
--- a/manager/src/main/resources/application.properties
+++ b/manager/src/main/resources/application.properties
@@ -19,3 +19,4 @@ gingersnap.rule.us-east.connector.schema=debezium
 gingersnap.rule.us-east.connector.table=customer
 
 quarkus.devservices.enabled=false
+quarkus.elasticsearch.health.enabled=false

--- a/manager/src/test/java/io/gingersnapproject/health/HealthCheckerTest.java
+++ b/manager/src/test/java/io/gingersnapproject/health/HealthCheckerTest.java
@@ -1,0 +1,21 @@
+package io.gingersnapproject.health;
+
+import static io.restassured.RestAssured.given;
+
+import org.junit.jupiter.api.Test;
+
+import io.gingersnapproject.mysql.MySQLResources;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@QuarkusTestResource(MySQLResources.class)
+public class HealthCheckerTest {
+   @Test
+   public void testHealthEndpointDefined() {
+      given()
+            .when().get("/q/health/ready")
+            .then()
+            .statusCode(200);
+   }
+}


### PR DESCRIPTION
Add HealthCheckerTest

In the future once a Rule is marked as queryable, we should include an
additional @Readiness check to ensure that the Elasticsearch client can
communicate with the backends when one or more Rules with query support
exist.
