### PR TITLE
Query enable by rule

### DIFF
--- a/manager/src/main/java/io/gingersnapproject/Caches.java
+++ b/manager/src/main/java/io/gingersnapproject/Caches.java
@@ -17,7 +17,7 @@ import io.gingersnapproject.database.DatabaseHandler;
 import io.gingersnapproject.metrics.CacheAccessRecord;
 import io.gingersnapproject.metrics.CacheManagerMetrics;
 import io.gingersnapproject.mutiny.UniItem;
-import io.gingersnapproject.search.QueryHandler;
+import io.gingersnapproject.search.IndexingHandler;
 import io.smallrye.mutiny.Uni;
 
 @Singleton
@@ -33,7 +33,7 @@ public class Caches {
    Configuration configuration;
 
    @Inject
-   QueryHandler queryHandler;
+   IndexingHandler indexingHandler;
 
    public ConcurrentMap<String, Cache<String, List<byte[]>>> getMultiMaps() {
       return multiMaps;
@@ -88,7 +88,7 @@ public class Caches {
    }
 
    public Uni<String> put(String name, String key, String value) {
-      Uni<String> indexUni = queryHandler.put(name, key, value)
+      Uni<String> indexUni = indexingHandler.put(name, key, value)
                   .map(___ -> value)
             // Make sure subsequent subscriptions don't update index again
                   .memoize().indefinitely();
@@ -120,7 +120,7 @@ public class Caches {
    }
 
    public Uni<Boolean> remove(String name, String key) {
-      Uni<String> indexUni = queryHandler.remove(name, key)
+      Uni<String> indexUni = indexingHandler.remove(name, key)
             .<String>map(___ -> null)
             // Make sure subsequent subscriptions don't update index again
             .memoize().indefinitely();

--- a/manager/src/main/java/io/gingersnapproject/Caches.java
+++ b/manager/src/main/java/io/gingersnapproject/Caches.java
@@ -17,7 +17,7 @@ import io.gingersnapproject.database.DatabaseHandler;
 import io.gingersnapproject.metrics.CacheAccessRecord;
 import io.gingersnapproject.metrics.CacheManagerMetrics;
 import io.gingersnapproject.mutiny.UniItem;
-import io.gingersnapproject.search.SearchBackend;
+import io.gingersnapproject.search.QueryHandler;
 import io.smallrye.mutiny.Uni;
 
 @Singleton
@@ -33,7 +33,7 @@ public class Caches {
    Configuration configuration;
 
    @Inject
-   SearchBackend searchBackend;
+   QueryHandler queryHandler;
 
    public ConcurrentMap<String, Cache<String, List<byte[]>>> getMultiMaps() {
       return multiMaps;
@@ -88,7 +88,7 @@ public class Caches {
    }
 
    public Uni<String> put(String name, String key, String value) {
-      Uni<String> indexUni = searchBackend.put(name, key, value)
+      Uni<String> indexUni = queryHandler.put(name, key, value)
                   .map(___ -> value)
             // Make sure subsequent subscriptions don't update index again
                   .memoize().indefinitely();
@@ -120,7 +120,7 @@ public class Caches {
    }
 
    public Uni<Boolean> remove(String name, String key) {
-      Uni<String> indexUni = searchBackend.remove(name, key)
+      Uni<String> indexUni = queryHandler.remove(name, key)
             .<String>map(___ -> null)
             // Make sure subsequent subscriptions don't update index again
             .memoize().indefinitely();

--- a/manager/src/main/java/io/gingersnapproject/configuration/Rule.java
+++ b/manager/src/main/java/io/gingersnapproject/configuration/Rule.java
@@ -16,6 +16,9 @@ public interface Rule {
 
       String selectStatement();
 
+      @WithDefault("false")
+      boolean queryEnabled();
+
       enum KeyType {
             PLAIN {
                   @Override

--- a/manager/src/main/java/io/gingersnapproject/search/IndexingHandler.java
+++ b/manager/src/main/java/io/gingersnapproject/search/IndexingHandler.java
@@ -1,0 +1,34 @@
+package io.gingersnapproject.search;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import io.gingersnapproject.configuration.Configuration;
+import io.gingersnapproject.configuration.Rule;
+import io.smallrye.mutiny.Uni;
+
+@Singleton
+public class IndexingHandler {
+
+   @Inject
+   SearchBackend searchBackend;
+
+   @Inject
+   Configuration configuration;
+
+   public Uni<String> put(String indexName, String documentId, String jsonString) {
+      Rule rule = configuration.rules().get(indexName);
+      if (rule == null || !rule.queryEnabled()) {
+         return Uni.createFrom().nullItem();
+      }
+      return searchBackend.put(indexName, documentId, jsonString);
+   }
+
+   public Uni<String> remove(String indexName, String documentId) {
+      Rule rule = configuration.rules().get(indexName);
+      if (rule == null || !rule.queryEnabled()) {
+         return Uni.createFrom().nullItem();
+      }
+      return searchBackend.remove(indexName, documentId);
+   }
+}

--- a/manager/src/main/java/io/gingersnapproject/search/NoOpSearchBackend.java
+++ b/manager/src/main/java/io/gingersnapproject/search/NoOpSearchBackend.java
@@ -6,18 +6,13 @@ import io.smallrye.mutiny.Uni;
 @LookupIfProperty(name = SearchBackend.PROPERTY, stringValue = "none", lookupIfMissing = true)
 public class NoOpSearchBackend implements SearchBackend {
    @Override
-   public Uni<String> mapping(String indexName) {
-      return Uni.createFrom().nullItem();
-   }
-
-   @Override
    public Uni<String> put(String indexName, String documentId, String jsonString) {
-      return Uni.createFrom().nullItem();
+      return Uni.createFrom().failure(new IllegalStateException("Index service is not enabled, this can be enabled by supplying a property for " + SearchBackend.PROPERTY));
    }
 
    @Override
    public Uni<String> remove(String indexName, String documentId) {
-      return Uni.createFrom().nullItem();
+      return Uni.createFrom().failure(new IllegalStateException("Index service is not enabled, this can be enabled by supplying a property for " + SearchBackend.PROPERTY));
    }
 
    @Override

--- a/manager/src/main/java/io/gingersnapproject/search/QueryHandler.java
+++ b/manager/src/main/java/io/gingersnapproject/search/QueryHandler.java
@@ -4,8 +4,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import io.gingersnapproject.Caches;
-import io.gingersnapproject.configuration.Configuration;
-import io.gingersnapproject.configuration.Rule;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
@@ -15,24 +13,6 @@ public class QueryHandler {
    Caches caches;
    @Inject
    SearchBackend searchBackend;
-   @Inject
-   Configuration configuration;
-
-   public Uni<String> put(String indexName, String documentId, String jsonString) {
-      Rule rule = configuration.rules().get(indexName);
-      if (rule == null || !rule.queryEnabled()) {
-         return Uni.createFrom().nullItem();
-      }
-      return searchBackend.put(indexName, documentId, jsonString);
-   }
-
-   public Uni<String> remove(String indexName, String documentId) {
-      Rule rule = configuration.rules().get(indexName);
-      if (rule == null || !rule.queryEnabled()) {
-         return Uni.createFrom().nullItem();
-      }
-      return searchBackend.remove(indexName, documentId);
-   }
 
    public Multi<String> query(String query) {
       Uni<SearchResult> result = searchBackend.query(query);

--- a/manager/src/main/java/io/gingersnapproject/search/QueryHandler.java
+++ b/manager/src/main/java/io/gingersnapproject/search/QueryHandler.java
@@ -4,6 +4,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import io.gingersnapproject.Caches;
+import io.gingersnapproject.configuration.Configuration;
+import io.gingersnapproject.configuration.Rule;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
@@ -11,9 +13,26 @@ import io.smallrye.mutiny.Uni;
 public class QueryHandler {
    @Inject
    Caches caches;
-
    @Inject
    SearchBackend searchBackend;
+   @Inject
+   Configuration configuration;
+
+   public Uni<String> put(String indexName, String documentId, String jsonString) {
+      Rule rule = configuration.rules().get(indexName);
+      if (rule == null || !rule.queryEnabled()) {
+         return Uni.createFrom().nullItem();
+      }
+      return searchBackend.put(indexName, documentId, jsonString);
+   }
+
+   public Uni<String> remove(String indexName, String documentId) {
+      Rule rule = configuration.rules().get(indexName);
+      if (rule == null || !rule.queryEnabled()) {
+         return Uni.createFrom().nullItem();
+      }
+      return searchBackend.remove(indexName, documentId);
+   }
 
    public Multi<String> query(String query) {
       Uni<SearchResult> result = searchBackend.query(query);

--- a/manager/src/main/java/io/gingersnapproject/search/SearchBackend.java
+++ b/manager/src/main/java/io/gingersnapproject/search/SearchBackend.java
@@ -6,8 +6,6 @@ public interface SearchBackend {
 
    String PROPERTY = "service.index";
 
-   Uni<String> mapping(String indexName);
-
    Uni<String> put(String indexName, String documentId, String jsonString);
 
    Uni<String> remove(String indexName, String documentId);

--- a/manager/src/main/java/io/gingersnapproject/search/opensearch/OpenSearchBackend.java
+++ b/manager/src/main/java/io/gingersnapproject/search/opensearch/OpenSearchBackend.java
@@ -24,7 +24,6 @@ public class OpenSearchBackend implements SearchBackend {
 
    Set<String> mappedRules = ConcurrentHashMap.newKeySet();
 
-   @Override
    public Uni<String> mapping(String indexName) {
       Request request = new Request("PUT", "/" + indexName);
 

--- a/manager/src/main/resources/application.properties
+++ b/manager/src/main/resources/application.properties
@@ -14,6 +14,7 @@ quarkus.datasource.reactive.url=mysql://localhost:3306/debezium
 gingersnap.rule.us-east.key-type=PLAIN
 gingersnap.rule.us-east.plain-separator=:
 gingersnap.rule.us-east.select-statement=select fullname, email from customer where fullname = ?
+gingersnap.rule.us-east.query-enabled=true
 
 gingersnap.rule.us-east.connector.schema=debezium
 gingersnap.rule.us-east.connector.table=customer

--- a/manager/src/test/java/io/gingersnapproject/mysql/MySQLResources.java
+++ b/manager/src/test/java/io/gingersnapproject/mysql/MySQLResources.java
@@ -1,10 +1,12 @@
 package io.gingersnapproject.mysql;
 
-import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.MountableFile;
 
-import java.util.Map;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
 
 public class MySQLResources implements QuarkusTestResourceLifecycleManager {
 
@@ -22,17 +24,29 @@ public class MySQLResources implements QuarkusTestResourceLifecycleManager {
                 .withCopyFileToContainer(MountableFile.forClasspathResource("setup.sql"), "/docker-entrypoint-initdb.d/setup.sql");
         db.start();
 
-        return Map.of(
-                "quarkus.datasource.db-kind", "MYSQL",
-                "quarkus.datasource.username", db.getUsername(),
-                "quarkus.datasource.password", db.getPassword(),
-                "quarkus.datasource.reactive.url", String.format("mysql://%s:%d/debezium", db.getHost(), db.getMappedPort(MySQLContainer.MYSQL_PORT)),
-                "gingersnap.rule.us-east.key-type", "PLAIN",
-                "gingersnap.rule.us-east.plain-separator", ":",
-                "gingersnap.rule.us-east.select-statement", "select fullname, email from customer where id = ?",
-                "gingersnap.rule.us-east.connector.schema", "debezium",
-                "gingersnap.rule.us-east.connector.table", "customer"
-        );
+        Map<String, String> properties = new HashMap<>(Map.of(
+              "quarkus.datasource.db-kind", "MYSQL",
+              "quarkus.datasource.username", db.getUsername(),
+              "quarkus.datasource.password", db.getPassword(),
+              "quarkus.datasource.reactive.url", String.format("mysql://%s:%d/debezium", db.getHost(), db.getMappedPort(MySQLContainer.MYSQL_PORT)),
+
+              "gingersnap.rule.us-east.key-type", "PLAIN",
+              "gingersnap.rule.us-east.plain-separator", ":",
+              "gingersnap.rule.us-east.select-statement", "select fullname, email from customer where id = ?",
+              "gingersnap.rule.us-east.connector.schema", "debezium",
+              "gingersnap.rule.us-east.connector.table", "customer"));
+
+        for (int i = 1; i < 4; ++i) {
+            properties.putAll(Map.of(
+                  "gingersnap.rule.developers-" + i + ".key-type", "PLAIN",
+                  "gingersnap.rule.developers-" + i + ".plain-separator", ":",
+                  "gingersnap.rule.developers-" + i + ".select-statement", "select fullname, email from customer where id = ?",
+                  "gingersnap.rule.developers-" + i + ".query-enabled", "true",
+                  "gingersnap.rule.developers-" + i + ".connector.schema", "debezium",
+                  "gingersnap.rule.developers-" + i + ".connector.table", "developers-" + i));
+        }
+
+        return properties;
     }
 
     @Override

--- a/manager/src/test/java/io/gingersnapproject/search/SearchBackendTest.java
+++ b/manager/src/test/java/io/gingersnapproject/search/SearchBackendTest.java
@@ -11,6 +11,7 @@ import org.infinispan.commons.dataconversion.internal.Json;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
+import io.gingersnapproject.search.opensearch.OpenSearchBackend;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.smallrye.mutiny.Uni;
@@ -23,7 +24,7 @@ public class SearchBackendTest {
    private static final String INDEX_NAME = "developers-1";
 
    @Inject
-   SearchBackend searchBackend;
+   OpenSearchBackend searchBackend;
 
    @Test
    public void test() throws Exception {


### PR DESCRIPTION
Only allows for query operations to be performed on rules that have query enabled. If not enabled the query operation is just plainly ignored. Also if a user configures a rule with querying without a backend query provider it will error.