### PR TITLE
Timer metrics per rule

### DIFF
--- a/manager/src/main/java/io/gingersnapproject/Caches.java
+++ b/manager/src/main/java/io/gingersnapproject/Caches.java
@@ -71,7 +71,7 @@ public class Caches {
    }
 
    public Uni<String> get(String name, String key) {
-      CacheAccessRecord<String> cacheAccessRecord = metrics.recordCacheAccess();
+      CacheAccessRecord<String> cacheAccessRecord = metrics.recordCacheAccess(name);
       try {
          Uni<String> uni = getOrCreateMap(name).get(key);
          cacheAccessRecord.localHit(uni instanceof UniItem<String>);

--- a/manager/src/main/java/io/gingersnapproject/metrics/CacheManagerMetrics.java
+++ b/manager/src/main/java/io/gingersnapproject/metrics/CacheManagerMetrics.java
@@ -15,7 +15,7 @@ public interface CacheManagerMetrics {
     * @param <T> The value's type.
     * @return A {@link CacheAccessRecord} instance.
     */
-   <T> CacheAccessRecord<T> recordCacheAccess();
+   <T> CacheAccessRecord<T> recordCacheAccess(String rule);
 
    /**
     * Register metrics associated with the {@code rule} stored in {@code cache}.

--- a/manager/src/main/java/io/gingersnapproject/metrics/micrometer/TimerMetric.java
+++ b/manager/src/main/java/io/gingersnapproject/metrics/micrometer/TimerMetric.java
@@ -1,11 +1,11 @@
 package io.gingersnapproject.metrics.micrometer;
 
 public enum TimerMetric {
-    CACHE_LOCAL_HIT("cache_local_hit", "Gingersnap cache hits latency when the value is found locally"),
-    CACHE_LOCAL_MISS("cache_local_miss", "Gingersnap cache miss latency when a tombstone is found locally"),
-    CACHE_REMOTE_HIT("cache_hit_with_database", "Gingersnap cache hits latency when the value is fetched from the database"),
-    CACHE_REMOTE_MISS("cache_miss_with_database", "Gingersnap cache miss latency when the value is not found in the database"),
-    CACHE_ERROR("cache_error", "Gingersnap error latency");
+    CACHE_LOCAL_HIT("cache_local_hit_%s", "Gingersnap cache hits latency when the value is found locally"),
+    CACHE_LOCAL_MISS("cache_local_miss_%s", "Gingersnap cache miss latency when a tombstone is found locally"),
+    CACHE_REMOTE_HIT("cache_hit_with_database_%s", "Gingersnap cache hits latency when the value is fetched from the database"),
+    CACHE_REMOTE_MISS("cache_miss_with_database_%s", "Gingersnap cache miss latency when the value is not found in the database"),
+    CACHE_ERROR("cache_error_%s", "Gingersnap error latency");
 
     private final String metricName;
     private final String description;
@@ -15,8 +15,8 @@ public enum TimerMetric {
         this.description = description;
     }
 
-    public String metricName() {
-        return metricName;
+    public String metricName(String rule) {
+        return String.format(metricName, rule);
     }
 
     public String description() {

--- a/manager/src/test/java/io/gingersnapproject/metrics/MetricsResourceTest.java
+++ b/manager/src/test/java/io/gingersnapproject/metrics/MetricsResourceTest.java
@@ -59,9 +59,8 @@ public class MetricsResourceTest {
       assertTimerMetricsValue(expectedCount);
       assertGaugeMetricsValue(expectedGauge, MySQLResources.RULE);
 
-      // cache error
+      // rule is never created, metrics remains the same
       given().when().get(GET_PATH, "non-existing-rule", "100000").then().statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-      expectedCount.put(TimerMetric.CACHE_ERROR, "1.0");
       assertTimerMetricsValue(expectedCount);
       assertGaugeMetricsValue(expectedGauge, MySQLResources.RULE);
    }
@@ -86,7 +85,7 @@ public class MetricsResourceTest {
    }
 
    private static Matcher<String> convertToContainsString(Map.Entry<TimerMetric, String> entry) {
-      return containsString(format(TIMER_METRIC_FORMAT, entry.getKey().metricName(), entry.getValue()));
+      return containsString(format(TIMER_METRIC_FORMAT, entry.getKey().metricName(MySQLResources.RULE).replace('-', '_'), entry.getValue()));
    }
 
    private static Matcher<String> convertToContainsString(Map.Entry<PerRuleGaugeMetric, String> entry, String rule) {


### PR DESCRIPTION
The timer metrics were global before. Recording the latency of all searches, etc, with this change we have timers per rule. We record the latency of rules instead of a global one.