### PR TITLE
Adding integration test

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -30,4 +30,6 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Build native executable
-        run: mvn package -Pnative
+        run: |
+          mvn package -Pnative -DexcludedGroups=integration-native
+          mvn test -Dquarkus.test.profile=integration-native -Dgroups=integration-native

--- a/manager/src/test/java/io/gingersnapproject/profile/GingersnapIntegrationTest.java
+++ b/manager/src/test/java/io/gingersnapproject/profile/GingersnapIntegrationTest.java
@@ -1,0 +1,18 @@
+package io.gingersnapproject.profile;
+
+import static io.gingersnapproject.profile.IntegrationNativeProfile.INTEGRATION_NATIVE;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Tag;
+
+
+@Tag(INTEGRATION_NATIVE)
+@TestProfile(IntegrationNativeProfile.class)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GingersnapIntegrationTest { }

--- a/manager/src/test/java/io/gingersnapproject/profile/IntegrationNativeProfile.java
+++ b/manager/src/test/java/io/gingersnapproject/profile/IntegrationNativeProfile.java
@@ -1,0 +1,12 @@
+package io.gingersnapproject.profile;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class IntegrationNativeProfile implements QuarkusTestProfile {
+   public static final String INTEGRATION_NATIVE = "integration-native";
+
+   @Override
+   public String getConfigProfile() {
+      return INTEGRATION_NATIVE;
+   }
+}

--- a/manager/src/test/java/io/gingersnapproject/rest/RuleResourcesTest.java
+++ b/manager/src/test/java/io/gingersnapproject/rest/RuleResourcesTest.java
@@ -1,0 +1,26 @@
+package io.gingersnapproject.rest;
+
+import static io.restassured.RestAssured.given;
+
+import io.gingersnapproject.mysql.MySQLResources;
+import io.gingersnapproject.profile.GingersnapIntegrationTest;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+@QuarkusIntegrationTest
+@GingersnapIntegrationTest
+@QuarkusTestResource(MySQLResources.class)
+public class RuleResourcesTest {
+
+   @Test
+   public void testRetrieveRuleKeys() {
+      given()
+            .when().get("/rules/" + MySQLResources.RULE)
+            .then()
+            .statusCode(200)
+            .body("", Matchers.emptyCollectionOf(String.class));
+   }
+}


### PR DESCRIPTION
Simple integration test to run the native-built image. Using tags and profiles for distinct integration tests.

See: https://github.com/gingersnap-project/cache-manager/pull/33#issuecomment-1365916797