### PR TITLE
Add E2E tests to pull requests

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -79,3 +79,10 @@ jobs:
         with:
           name: oracle-test-results
           path: ${{ env.TEST_OUTPUT_DIR }}
+
+  e2e:
+    needs: build
+    uses: gingersnap-project/e2e/.github/workflows/e2e.yaml@main
+    with:
+      cache-manager-ref: ${{ github.ref }}
+      cache-manager-repository: ${{ github.repository }}


### PR DESCRIPTION
This should result in all the cache-manager images being created and then executed in the E2E testsuite with the most recent Operator code and db-syncer image.