### PR TITLE
Don't set k8s configuration in default application.properties

### DIFF
--- a/manager/src/main/resources/application.properties
+++ b/manager/src/main/resources/application.properties
@@ -18,8 +18,4 @@ quarkus.smallrye-openapi.info-license-url=https://www.apache.org/licenses/LICENS
 quarkus.devservices.enabled=false
 quarkus.elasticsearch.health.enabled=false
 
-## Kubernetes Configuration
-gingersnap.k8s.eager-config-map=eager-config-map
-gingersnap.k8s.lazy-config-map=lazy-config-map
-gingersnap.k8s.namespace=default
 quarkus.grpc.server.use-separate-server=false


### PR DESCRIPTION
We need to disable this by default so that calls to `docker run ...` and `quarkus dev`  don't fail when k8s is not available.