### PR TITLE
Add ServiceBinding Startup and Readiness health check

### DIFF
--- a/manager/src/main/java/io/gingersnapproject/health/HotRodHealthChecks.java
+++ b/manager/src/main/java/io/gingersnapproject/health/HotRodHealthChecks.java
@@ -11,7 +11,7 @@ import org.eclipse.microprofile.health.Startup;
 import io.gingersnapproject.HotRodServer;
 import io.quarkus.arc.Arc;
 
-public class HealthChecks {
+public class HotRodHealthChecks {
 
    private static final String SERVER_CHECK_NAME = "HotRod Server";
 

--- a/manager/src/main/java/io/gingersnapproject/health/ServiceBindingHealthChecks.java
+++ b/manager/src/main/java/io/gingersnapproject/health/ServiceBindingHealthChecks.java
@@ -1,0 +1,34 @@
+package io.gingersnapproject.health;
+
+import io.gingersnapproject.k8s.configuration.KubernetesConfiguration;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+import org.eclipse.microprofile.health.Startup;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+public class ServiceBindingHealthChecks {
+
+    private static final String SERVER_CHECK_NAME = "ServiceBinding";
+
+    @Readiness
+    @Startup
+    @Singleton
+    public static class RootDefined implements HealthCheck {
+
+        private static final boolean SERVICE_BINDING_ROOT_DEFINED = System.getenv("SERVICE_BINDING_ROOT") != null;
+
+        @Inject
+        KubernetesConfiguration config;
+
+        @Override
+        public HealthCheckResponse call() {
+            return HealthCheckResponse.builder()
+                    .name(SERVER_CHECK_NAME)
+                    .status(!config.serviceBindingRequired() || SERVICE_BINDING_ROOT_DEFINED)
+                    .build();
+        }
+    }
+}

--- a/manager/src/main/java/io/gingersnapproject/k8s/configuration/KubernetesConfiguration.java
+++ b/manager/src/main/java/io/gingersnapproject/k8s/configuration/KubernetesConfiguration.java
@@ -17,4 +17,8 @@ public interface KubernetesConfiguration {
 
    @WithDefault("default")
    String namespace();
+
+   @WithDefault("false")
+   @WithName("service-binding-required")
+   boolean serviceBindingRequired();
 }


### PR DESCRIPTION
This is necessary to prevent cache pod(s) being marked as Ready=True before the ServiceBinding operator has updated the cache Deployment/Daemonset to include the binding mount.