### PR TITLE
Utilise ubi-micro as native runtime image

### DIFF
--- a/manager/src/main/docker/Dockerfile.native-micro-builder
+++ b/manager/src/main/docker/Dockerfile.native-micro-builder
@@ -1,4 +1,4 @@
-FROM quay.io/quarkus/ubi-quarkus-native-image:22.2.0-java17 AS build
+FROM quay.io/quarkus/ubi-quarkus-native-image:22.3-java17 AS build
 ARG DB_VENDOR
 COPY --chown=quarkus:quarkus mvnw /code/mvnw
 COPY --chown=quarkus:quarkus .mvn /code/.mvn

--- a/manager/src/main/docker/Dockerfile.native-micro-builder
+++ b/manager/src/main/docker/Dockerfile.native-micro-builder
@@ -9,7 +9,7 @@ COPY --chown=quarkus:quarkus infinispan /code/infinispan
 COPY --chown=quarkus:quarkus manager /code/manager
 RUN ./mvnw package -Pnative -Pno-submodule-update -P${DB_VENDOR} -DskipTests
 
-FROM quay.io/quarkus/quarkus-micro-image:1.0
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 WORKDIR /work/
 COPY --from=build /code/manager/target/*-runner /work/application
 


### PR DESCRIPTION
tldr; Revert in the future, but necessary evil for docker-compose health checks which require `curl`. 

This significantly increases the image size, 252MB vs 187MB, however it
provides common utilities such as `curl`. In the future we should
utilise the `quarkus-micro-image` again and copy required dependencies
to the runtime image as required.

