### PR TITLE
Denormalize Eager rule db retrievals

### DIFF
--- a/manager/src/main/java/io/gingersnapproject/Caches.java
+++ b/manager/src/main/java/io/gingersnapproject/Caches.java
@@ -10,9 +10,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import org.infinispan.commons.dataconversion.internal.Json;
 import org.infinispan.util.KeyValuePair;
@@ -37,7 +37,7 @@ import io.gingersnapproject.search.IndexingHandler;
 import io.smallrye.mutiny.Uni;
 import io.smallrye.mutiny.groups.UniJoin;
 
-@Singleton
+@ApplicationScoped
 public class Caches {
    private static final Logger log = LoggerFactory.getLogger(Caches.class);
 

--- a/manager/src/main/java/io/gingersnapproject/HotRodServer.java
+++ b/manager/src/main/java/io/gingersnapproject/HotRodServer.java
@@ -2,9 +2,9 @@ package io.gingersnapproject;
 
 import java.net.InetSocketAddress;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import org.infinispan.commons.logging.LogFactory;
 import org.infinispan.server.core.logging.Log;
@@ -20,7 +20,7 @@ import io.netty.channel.ChannelInitializer;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 
-@Singleton
+@ApplicationScoped
 public class HotRodServer {
    static private final Log log = LogFactory.getLog(HotRodServer.class, Log.class);
 

--- a/manager/src/main/java/io/gingersnapproject/database/DatabaseHandler.java
+++ b/manager/src/main/java/io/gingersnapproject/database/DatabaseHandler.java
@@ -1,5 +1,6 @@
 package io.gingersnapproject.database;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -113,7 +114,15 @@ public class DatabaseHandler {
                Row row = rowIterator.next();
                Json jsonObject = Json.object();
                for (int i = 0; i < columns; ++i) {
-                  jsonObject.set(row.getColumnName(i), row.getValue(i));
+                  var val = row.getValue(i);
+                  Json json;
+                  try {
+                     json = Json.make(val);
+                  } catch (IllegalArgumentException e) {
+                     // Type is unknown to JSON, so we must use the toString() representation
+                     json = Json.make(val.toString());
+                  }
+                  jsonObject.set(row.getColumnName(i), json);
                }
                return jsonObject.toString();
             });

--- a/manager/src/main/java/io/gingersnapproject/health/HotRodHealthChecks.java
+++ b/manager/src/main/java/io/gingersnapproject/health/HotRodHealthChecks.java
@@ -1,7 +1,5 @@
 package io.gingersnapproject.health;
 
-import javax.inject.Singleton;
-
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;
@@ -11,12 +9,14 @@ import org.eclipse.microprofile.health.Startup;
 import io.gingersnapproject.HotRodServer;
 import io.quarkus.arc.Arc;
 
+import javax.enterprise.context.ApplicationScoped;
+
 public class HotRodHealthChecks {
 
    private static final String SERVER_CHECK_NAME = "HotRod Server";
 
    @Liveness
-   @Singleton
+   @ApplicationScoped
    public static class LivenessCheck implements HealthCheck {
       @Override
       public HealthCheckResponse call() {
@@ -28,7 +28,7 @@ public class HotRodHealthChecks {
    }
 
    @Readiness
-   @Singleton
+   @ApplicationScoped
    public static class ReadinessCheck implements HealthCheck {
       @Override
       public HealthCheckResponse call() {
@@ -40,7 +40,7 @@ public class HotRodHealthChecks {
    }
 
    @Startup
-   @Singleton
+   @ApplicationScoped
    public static class StartupCheck implements HealthCheck {
       @Override
       public HealthCheckResponse call() {

--- a/manager/src/main/java/io/gingersnapproject/health/ServiceBindingHealthChecks.java
+++ b/manager/src/main/java/io/gingersnapproject/health/ServiceBindingHealthChecks.java
@@ -6,8 +6,8 @@ import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 import org.eclipse.microprofile.health.Startup;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.inject.Singleton;
 
 public class ServiceBindingHealthChecks {
 
@@ -15,7 +15,7 @@ public class ServiceBindingHealthChecks {
 
     @Readiness
     @Startup
-    @Singleton
+    @ApplicationScoped
     public static class RootDefined implements HealthCheck {
 
         // Field can't be static, otherwise it is set at native build time

--- a/manager/src/main/java/io/gingersnapproject/search/IndexingHandler.java
+++ b/manager/src/main/java/io/gingersnapproject/search/IndexingHandler.java
@@ -2,15 +2,15 @@ package io.gingersnapproject.search;
 
 import java.util.Map;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import io.gingersnapproject.configuration.Configuration;
 import io.gingersnapproject.configuration.EagerRule;
 import io.smallrye.mutiny.Uni;
 
-@Singleton
+@ApplicationScoped
 public class IndexingHandler {
 
    @Inject

--- a/manager/src/main/java/io/gingersnapproject/search/QueryHandler.java
+++ b/manager/src/main/java/io/gingersnapproject/search/QueryHandler.java
@@ -1,14 +1,14 @@
 package io.gingersnapproject.search;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
-import javax.inject.Singleton;
 
 import io.gingersnapproject.Caches;
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
 
-@Singleton
+@ApplicationScoped
 public class QueryHandler {
 
    @Inject

--- a/manager/src/test/java/io/gingersnapproject/hotrod/HotRodOperationsTest.java
+++ b/manager/src/test/java/io/gingersnapproject/hotrod/HotRodOperationsTest.java
@@ -48,15 +48,12 @@ public class HotRodOperationsTest {
 
    @Test
    public void testGetAll() {
-      Map<String, String> values = new HashMap<>();
-      values.put("key1", "value1");
-      values.put("key3", "value3");
-      values.put("key2", "value3");
-
-      cache.put("key1", "value1");
-      cache.put("key3", "value3");
-      cache.put("key2", "value3");
-
+      var values = Map.of(
+              "key1", "{\"fullname\": \"value1\"}",
+              "key2", "{\"fullname\": \"value2\"}",
+              "key3", "{\"fullname\": \"value3\"}"
+      );
+      cache.putAll(values);
       assertThat(cache.getAll(values.keySet())).isEqualTo(values);
    }
 }

--- a/manager/src/test/java/io/gingersnapproject/oracle/OracleResource.java
+++ b/manager/src/test/java/io/gingersnapproject/oracle/OracleResource.java
@@ -34,7 +34,7 @@ public class OracleResource implements Database {
             .withPassword("password")
             .withCopyFileToContainer(forClasspathResource("oracle/oracle-setup.sql"), "/docker-entrypoint-initdb.d/001_setup.sql")
             .withCopyFileToContainer(forClasspathResource("oracle/populate.sh"), "/docker-entrypoint-initdb.d/002_populate.sh")
-            .withCopyFileToContainer(forClasspathResource("populate.sql"), "/sql/populate.sql");
+            .withCopyFileToContainer(forClasspathResource("oracle/populate.sql"), "/sql/populate.sql");
       db.start();
    }
 

--- a/manager/src/test/java/io/gingersnapproject/rules/EagerRuleTest.java
+++ b/manager/src/test/java/io/gingersnapproject/rules/EagerRuleTest.java
@@ -1,0 +1,39 @@
+package io.gingersnapproject.rules;
+
+import io.gingersnapproject.database.DatabaseResourcesLifecyleManager;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+@QuarkusTest
+@QuarkusTestResource(value = DatabaseResourcesLifecyleManager.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class EagerRuleTest {
+    @Test
+    public void lazyLoadOnMiss() {
+        // No values have been added via HotRod, so the DB will be queried
+        given().when()
+                .get("/rules/airport/1")
+                .then()
+                .body("name", equalTo("Newcastle"));
+
+        given().when()
+                .get("/rules/airport/3")
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    public void testJoinOnLazyLoad() {
+        given().when()
+                .get("/rules/flight/1")
+                .then()
+                .body("airline_id.name", equalTo("British Airways"))
+                .body("origin_id.name", equalTo("Newcastle"))
+                .body("destination_id.name", equalTo("Knock"));
+    }
+}

--- a/manager/src/test/java/io/gingersnapproject/rules/LazyRuleTest.java
+++ b/manager/src/test/java/io/gingersnapproject/rules/LazyRuleTest.java
@@ -1,0 +1,29 @@
+package io.gingersnapproject.rules;
+
+import io.gingersnapproject.database.DatabaseResourcesLifecyleManager;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+@QuarkusTest
+@QuarkusTestResource(value = DatabaseResourcesLifecyleManager.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class LazyRuleTest {
+    @Test
+    public void lazyLoad() {
+        // No values have been added via HotRod, so the DB will be queried
+        given().when()
+                .get("/rules/lazy-flight/1")
+                .then()
+                .body("name", equalTo("BA1234"));
+
+        given().when()
+                .get("/rules/lazy-flight/3")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/manager/src/test/resources/mssql/mssql-test.properties
+++ b/manager/src/test/resources/mssql/mssql-test.properties
@@ -10,6 +10,10 @@ gingersnap.eager-rule.gate.select-statement=select name from gingersnap.gate whe
 gingersnap.eager-rule.gate.connector.schema=gingersnap
 gingersnap.eager-rule.gate.connector.table=gate
 
+gingersnap.lazy-rule.lazy-flight.key-type=TEXT
+gingersnap.lazy-rule.lazy-flight.plain-separator=:
+gingersnap.lazy-rule.lazy-flight.select-statement=select name, scheduled_time, gate_id, airline_id, origin_id, destination_id from gingersnap.flight where id = @P1
+
 gingersnap.eager-rule.flight.key-type=TEXT
 gingersnap.eager-rule.flight.plain-separator=:
 gingersnap.eager-rule.flight.select-statement=select name, scheduled_time, gate_id, airline_id, origin_id, destination_id from gingersnap.flight where id = @P1

--- a/manager/src/test/resources/mysql/mysql-test.properties
+++ b/manager/src/test/resources/mysql/mysql-test.properties
@@ -10,6 +10,10 @@ gingersnap.eager-rule.gate.select-statement=select name from gate where id = ?
 gingersnap.eager-rule.gate.connector.schema=gingersnap
 gingersnap.eager-rule.gate.connector.table=gate
 
+gingersnap.lazy-rule.lazy-flight.key-type=TEXT
+gingersnap.lazy-rule.lazy-flight.plain-separator=:
+gingersnap.lazy-rule.lazy-flight.select-statement=select name, scheduled_time, gate_id, airline_id, origin_id, destination_id from flight where id = ?
+
 gingersnap.eager-rule.flight.key-type=TEXT
 gingersnap.eager-rule.flight.plain-separator=:
 gingersnap.eager-rule.flight.select-statement=select name, scheduled_time, gate_id, airline_id, origin_id, destination_id from flight where id = ?

--- a/manager/src/test/resources/oracle/oracle-test.properties
+++ b/manager/src/test/resources/oracle/oracle-test.properties
@@ -12,7 +12,7 @@ gingersnap.eager-rule.gate.connector.table=gate
 
 gingersnap.eager-rule.flight.key-type=TEXT
 gingersnap.eager-rule.flight.plain-separator=:
-gingersnap.eager-rule.flight.select-statement=select "name", scheduled_time, "gate_id", "airline_id", "origin_id", "destination_id" from flight where "id" = ?
+gingersnap.eager-rule.flight.select-statement=select "name", "scheduled_time", "gate_id", "airline_id", "origin_id", "destination_id" from flight where "id" = ?
 gingersnap.eager-rule.flight.query-enabled=true
 gingersnap.eager-rule.flight.connector.schema=gingersnap
 gingersnap.eager-rule.flight.connector.table=flight

--- a/manager/src/test/resources/oracle/oracle-test.properties
+++ b/manager/src/test/resources/oracle/oracle-test.properties
@@ -10,6 +10,10 @@ gingersnap.eager-rule.gate.select-statement=select "name" from gate where "id" =
 gingersnap.eager-rule.gate.connector.schema=gingersnap
 gingersnap.eager-rule.gate.connector.table=gate
 
+gingersnap.lazy-rule.lazy-flight.key-type=TEXT
+gingersnap.lazy-rule.lazy-flight.plain-separator=:
+gingersnap.lazy-rule.lazy-flight.select-statement=select "name", "scheduled_time", "gate_id", "airline_id", "origin_id", "destination_id" from flight where "id" = ?
+
 gingersnap.eager-rule.flight.key-type=TEXT
 gingersnap.eager-rule.flight.plain-separator=:
 gingersnap.eager-rule.flight.select-statement=select "name", "scheduled_time", "gate_id", "airline_id", "origin_id", "destination_id" from flight where "id" = ?

--- a/manager/src/test/resources/oracle/populate.sql
+++ b/manager/src/test/resources/oracle/populate.sql
@@ -1,3 +1,4 @@
+WHENEVER SQLERROR EXIT SQL.SQLCODE
 insert into gingersnap.customer values (1, 'Jon Doe', 'jd@example.com');
 insert into gingersnap.customer values (3, 'Bob', 'bob@example.com');
 insert into gingersnap.customer values (4, 'Alice', 'alice@example.com');
@@ -16,5 +17,5 @@ insert into gingersnap.gate values (3, 'B1');
 insert into gingersnap.airport values (1, 'Newcastle');
 insert into gingersnap.airport values (2, 'Knock');
 
-insert into gingersnap.flight values (1, 'BA1234', '2017-10-12 08:30:00', 1, 1, 1, 2);
-insert into gingersnap.flight values (2, 'AF5678', '2017-10-20 09:50:00', 2, 2, 2, 1);
+insert into gingersnap.flight values (1, 'BA1234', timestamp '2017-10-12 08:30:00', 1, 1, 1, 2);
+insert into gingersnap.flight values (2, 'AF5678', timestamp '2017-10-20 09:50:00', 2, 2, 2, 1);

--- a/manager/src/test/resources/postgres/postgres-test.properties
+++ b/manager/src/test/resources/postgres/postgres-test.properties
@@ -10,6 +10,10 @@ gingersnap.eager-rule.gate.select-statement=select name from gate where id = $1
 gingersnap.eager-rule.gate.connector.schema=gingersnap
 gingersnap.eager-rule.gate.connector.table=gate
 
+gingersnap.lazy-rule.lazy-flight.key-type=TEXT
+gingersnap.lazy-rule.lazy-flight.plain-separator=:
+gingersnap.lazy-rule.lazy-flight.select-statement=select name, scheduled_time, gate_id, airline_id, origin_id, destination_id from flight where id = $1
+
 gingersnap.eager-rule.flight.key-type=TEXT
 gingersnap.eager-rule.flight.plain-separator=:
 gingersnap.eager-rule.flight.select-statement=select name, scheduled_time, gate_id, airline_id, origin_id, destination_id from flight where id = $1

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
 
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
@rigazilla I had to remove the lazy initialisation of the DatabaseHandler table data as this logic blocks the thread pool. I think changing all the dependent beans from `@Singleton` to `@ApplicationScoped` has fixed the issues you experienced with `DatabaseHandler#start()` ordering, but would