### PR TITLE
GraphQL POC

### DIFF
--- a/manager/pom.xml
+++ b/manager/pom.xml
@@ -20,6 +20,7 @@
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <protobuf-java-utils.version>3.11.4</protobuf-java-utils.version>
         <org.gingersnap.api.basedir>${project.basedir}/gingersnap-api</org.gingersnap.api.basedir>
+        <version.graphql>20.0</version.graphql>
     </properties>
 
     <dependencies>
@@ -63,6 +64,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.graphql-java</groupId>
+            <artifactId>graphql-java</artifactId>
+            <version>${version.graphql}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>

--- a/manager/src/main/java/io/gingersnapproject/Caches.java
+++ b/manager/src/main/java/io/gingersnapproject/Caches.java
@@ -87,7 +87,7 @@ public class Caches {
       UniJoin.Builder<Json> builder = Uni.join().builder();
       for (ForeignKey fk : table.foreignKeys()) {
          // TODO: handle composite fks
-         String fkColumn = fk.columns().get(0);
+         String fkColumn = fk.columns().get(0).name();
          if (json.at(fkColumn) == null)
             continue;
 

--- a/manager/src/main/java/io/gingersnapproject/Graph.java
+++ b/manager/src/main/java/io/gingersnapproject/Graph.java
@@ -1,0 +1,316 @@
+package io.gingersnapproject;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.idl.RuntimeWiring;
+import graphql.schema.idl.SchemaGenerator;
+import graphql.schema.idl.SchemaParser;
+import graphql.schema.idl.TypeDefinitionRegistry;
+import io.gingersnapproject.configuration.EagerRule;
+import io.gingersnapproject.configuration.RuleManager;
+import io.gingersnapproject.database.DatabaseHandler;
+import io.gingersnapproject.database.model.Column;
+import io.quarkus.runtime.StartupEvent;
+import org.infinispan.commons.dataconversion.internal.Json;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static graphql.Scalars.*;
+import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
+import static graphql.schema.GraphQLNonNull.nonNull;
+import static graphql.schema.idl.RuntimeWiring.newRuntimeWiring;
+
+@ApplicationScoped
+public class Graph {
+
+    @Inject
+    DatabaseHandler databaseHandler;
+
+    @Inject
+    RuleManager ruleManager;
+
+    @Inject
+    Caches caches;
+
+    void start(@Observes StartupEvent ignore) {
+    }
+
+    private GraphQL generate() {
+        // Need to register all types with !FK first
+        // Add these types to a map with the rule name as the key and the rule definition as the value
+        // Loop over rules with FK
+        // If FK(s) exist, but no Rule exists for one of the Types, continue
+        // If FK exists and Rule exists for type, define
+        // Use while loop to implement
+
+        // Process all rules without expansion or ForeignKeys
+        Map<String, GraphQLObjectType> typeMap = ruleManager.eagerRules()
+                .entrySet()
+                .stream()
+                .filter(e -> {
+                    var table = databaseHandler.table(e.getValue().connector().table());
+                    return !e.getValue().expandEntity() || table.foreignKeys().isEmpty();
+                })
+                .map(e -> {
+                    var table = databaseHandler.table(e.getValue().connector().table());
+                    var builder = GraphQLObjectType.newObject().name(e.getKey());
+                    table.columns().forEach(column -> builder.field(fieldDef(column)));
+                    return builder.build();
+                })
+                .collect(Collectors.toMap(GraphQLObjectType::getName, Function.identity()));
+
+        Map<String, EagerRule> fkRules =  ruleManager.eagerRules()
+                .entrySet()
+                .stream()
+                .filter(e -> !typeMap.containsKey(e.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        while (!fkRules.isEmpty()) {
+            var it = fkRules.entrySet().iterator();
+            while (it.hasNext()) {
+                var e = it.next();
+                var ruleName = e.getKey();
+                var rule = e.getValue();
+                var table = databaseHandler.table(rule.connector().table());
+                boolean fkTypeDefined = true;
+                for (var fk : table.foreignKeys()) {
+                    var tableRule = databaseHandler.tableToRuleName(fk.refTable());
+                    if (!typeMap.containsKey(tableRule)) {
+                        fkTypeDefined = false;
+                        break;
+                    }
+                }
+
+                // All FK rules defined, so we can define a Type for this rule
+                if (fkTypeDefined) {
+                    var builder = GraphQLObjectType.newObject().name(ruleName);
+                    var fkColumns = table.foreignKeys()
+                            .stream()
+                            .flatMap(fk -> fk.columns().stream())
+                            .collect(Collectors.toSet());
+
+                    // Define non-FK fields
+                    table.columns()
+                            .stream()
+                            .filter(c -> !fkColumns.contains(c))
+                            .forEach(column ->  builder.field(fieldDef(column)));
+
+                    // Define FK fields
+                    table.foreignKeys()
+                            .forEach(fk -> {
+                                var refRule = databaseHandler.tableToRuleName(fk.refTable());
+                                var refType = typeMap.get(refRule);
+                                var fkCol = fk.columns().get(0).name();
+                                builder.field(
+                                        newFieldDefinition()
+                                                .name(fkCol)
+                                                .type(refType)
+                                );
+                            });
+                    typeMap.put(ruleName, builder.build());
+                    it.remove();
+                }
+            }
+        }
+
+        var schemaBuilder = new GraphQLSchema.Builder();
+        var queryTypeBuilder = GraphQLObjectType.newObject().name("QueryType");
+        // Define QueryType function for rule and register types
+        typeMap.values().forEach(t -> {
+            schemaBuilder.additionalType(t);
+
+            var name = t.getName();
+            var rule = ruleManager.eagerRules().get(name);
+            var table = databaseHandler.table(rule.connector().table());
+
+            // TODO store as Map in Table?
+            var columnMap = table.columns().stream().collect(Collectors.toMap(Column::name, Function.identity()));
+            var keyColumns = rule.connector()
+                    .keyColumns()
+                    .stream()
+                    .map(columnMap::get)
+                    .toList();
+
+            var fieldBuilder = newFieldDefinition()
+                    .name(name)
+                    .type(t);
+
+            keyColumns.forEach(c ->
+                    fieldBuilder.argument(
+                            GraphQLArgument.newArgument()
+                                    .name(c.name())
+                                    .type(nonNull(GraphQLString))
+                                    .build()
+                    )
+            );
+
+            fieldBuilder.dataFetcher(environment -> {
+                // TODO handle JSON keys
+                var keyBuilder = new StringBuilder();
+                for (int i = 0; i < keyColumns.size(); i++) {
+                    var argName = keyColumns.get(i).name();
+                    var arg = environment.getArgument(argName);
+                    keyBuilder.append(arg);
+                    if (i != keyColumns.size() - 1)
+                        keyBuilder.append(rule.plainSeparator());
+                }
+
+                var key = keyBuilder.toString();
+                var entry = caches.get(name, key)
+                        .await()
+                        .atMost(Duration.ofSeconds(1));
+
+                // TODO correctly handle so that exception is returned via "errors"
+                if (entry == null)
+                    throw new Exception(String.format("Entry '%s' could not be found", key));
+
+                // TODO avoid back and forth between JSON -> MAP
+                return Json.read(entry).asMap();
+            });
+            queryTypeBuilder.field(fieldBuilder);
+        });
+
+        schemaBuilder.query(queryTypeBuilder);
+        var schema = schemaBuilder.build();
+        return GraphQL.newGraphQL(schema).build();
+    }
+
+    private GraphQLFieldDefinition fieldDef(Column c) {
+        return newFieldDefinition()
+                .name(c.name())
+                .type(graphQLType(c))
+                .build();
+    }
+
+    private GraphQLOutputType graphQLType(Column c) {
+        return switch (c.type()) {
+            case "BOOL" -> GraphQLBoolean;
+            case "INT" -> GraphQLInt;
+            default -> GraphQLString;
+        };
+    }
+
+    // `curl -X POST --data '{hello(name: "Ryan", email: "test@test.com"){name email}}' "http://localhost:8080/graphql"`
+    private GraphQL programmatic() {
+        var schemaBuilder = new GraphQLSchema.Builder();
+        var userType = GraphQLObjectType.newObject()
+                .name("User")
+                .field(
+                        newFieldDefinition()
+                                .name("name")
+                                .type(GraphQLString)
+                                .build()
+                )
+                .field(
+                        newFieldDefinition()
+                                .name("email")
+                                .type(GraphQLString)
+                                .build()
+                )
+                .build();
+
+        var queryType = GraphQLObjectType.newObject()
+                .name("QueryType")
+                .field(newFieldDefinition()
+                        .name("hello")
+                        .argument(
+                                GraphQLArgument.newArgument()
+                                        .name("name")
+                                        .type(nonNull(GraphQLString))
+                                        .build()
+                        )
+                        .argument(
+                                GraphQLArgument.newArgument()
+                                        .name("email")
+                                        .type(GraphQLString)
+                                        .build()
+                        )
+                        .type(userType)
+                        .dataFetcher(environment -> {
+                            var map = new HashMap<>(2);
+                            map.put("name", environment.getArgument("name"));
+                            map.put("email", environment.getArgument("email"));
+                            return map;
+                        })
+                        .build()
+                );
+        schemaBuilder.additionalType(userType);
+        schemaBuilder.query(queryType);
+
+        var schema = schemaBuilder.build();
+        return GraphQL.newGraphQL(schema).build();
+    }
+
+    // `curl -X POST --data '{hello(name: "Ryan", email: "test@test.com"){name email}}' "http://localhost:8080/graphql"`
+    private GraphQL declarative() {
+        String schema = """
+                type Query {
+                  hello(name: String!, email: String): User
+                }
+                                
+                type User {
+                  name: String
+                  email: String
+                }
+                    """;
+
+        SchemaParser schemaParser = new SchemaParser();
+        TypeDefinitionRegistry typeDefinitionRegistry = schemaParser.parse(schema);
+
+        RuntimeWiring runtimeWiring = newRuntimeWiring()
+                .type("Query",
+                        builder -> builder
+                                .dataFetcher("hello", environment -> {
+                                    environment.getArguments().forEach((k, v) -> System.out.printf("K=%s,V=%s", k, v));
+                                    var map = new HashMap<>(2);
+                                    map.put("name", environment.getArgument("name"));
+                                    map.put("email", environment.getArgument("email"));
+                                    return map;
+                                }))
+                .build();
+
+        SchemaGenerator schemaGenerator = new SchemaGenerator();
+        GraphQLSchema graphQLSchema = schemaGenerator.makeExecutableSchema(typeDefinitionRegistry, runtimeWiring);
+
+        return GraphQL.newGraphQL(graphQLSchema).build();
+    }
+
+    public String exec(String query) {
+        // Ordering, Pagination etc all done by passing args to the function https://graphql.org/learn/pagination/
+        //
+        // TODO generate following query methods:
+        // 1. rule(key: String!) rule
+        // 2. rules() [RuleConfig]
+        // rule(co1, col2, col3...) SQL query on Index to return all that match non-null args?
+
+        // Return the GraphQL schemas via the endpoint `curl -X POST --data '{__schema{queryType{fields{name}}}}' "http://localhost:8080/rules"`
+        // https://medium.com/@mrthankyou/how-to-get-a-graphql-schema-28915025de0e
+
+        GraphQL graphQL = generate();
+        ExecutionResult executionResult = graphQL.execute(query);
+        for (var e : executionResult.getErrors())
+            System.err.println(e);
+
+        var data = executionResult.getData();
+
+        // Create JSON
+        Json json = Json.object();
+        json.set("data", Json.make(data));
+        // TODO include errors
+        json.set("errors", Json.nil());
+        return json.toPrettyString();
+    }
+}

--- a/manager/src/main/java/io/gingersnapproject/GraphQLResource.java
+++ b/manager/src/main/java/io/gingersnapproject/GraphQLResource.java
@@ -1,0 +1,38 @@
+package io.gingersnapproject;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+// TODO https://graphql.org/learn/serving-over-http/
+@Path("/graphql")
+public class GraphQLResource {
+
+    @Inject
+    Graph graph;
+
+    @GET
+    @Path("schema.graphql")
+    public String get() {
+        return graph.exec("{__schema{queryType{fields{name}}}}");
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public String get(@QueryParam("query") String query) {
+        // TODO UNI
+        return graph.exec(query);
+    }
+
+    @POST
+    @Produces(MediaType.APPLICATION_JSON)
+    public String post(String payload) {
+        // TODO UNI
+        // TODO https://graphql.org/learn/serving-over-http/
+        return graph.exec(payload);
+    }
+}

--- a/manager/src/main/java/io/gingersnapproject/configuration/Connector.java
+++ b/manager/src/main/java/io/gingersnapproject/configuration/Connector.java
@@ -1,6 +1,9 @@
 package io.gingersnapproject.configuration;
 
 import io.quarkus.runtime.annotations.ConfigGroup;
+import io.smallrye.config.WithDefault;
+
+import java.util.List;
 
 @ConfigGroup
 public interface Connector {
@@ -8,4 +11,9 @@ public interface Connector {
    String schema();
 
    String table();
+
+   List<String> keyColumns();
+
+   @WithDefault("*")
+   List<String> valueColumns();
 }

--- a/manager/src/main/java/io/gingersnapproject/configuration/EagerRule.java
+++ b/manager/src/main/java/io/gingersnapproject/configuration/EagerRule.java
@@ -1,6 +1,7 @@
 package io.gingersnapproject.configuration;
 import io.smallrye.config.WithDefault;
 
+// TODO expose Values? Check how Will handled this in his PR
 public interface EagerRule  extends Rule {
 
       Connector connector();

--- a/manager/src/main/java/io/gingersnapproject/database/model/Column.java
+++ b/manager/src/main/java/io/gingersnapproject/database/model/Column.java
@@ -1,0 +1,5 @@
+
+package io.gingersnapproject.database.model;
+
+public record Column(String name, String type) {
+}

--- a/manager/src/main/java/io/gingersnapproject/database/model/ForeignKey.java
+++ b/manager/src/main/java/io/gingersnapproject/database/model/ForeignKey.java
@@ -2,5 +2,5 @@ package io.gingersnapproject.database.model;
 
 import java.util.List;
 
-public record ForeignKey(String name, List<String> columns, String refTable, List<String> refColumns) {
+public record ForeignKey(String name, List<Column> columns, String refTable, List<String> refColumns) {
 }

--- a/manager/src/main/java/io/gingersnapproject/database/model/Table.java
+++ b/manager/src/main/java/io/gingersnapproject/database/model/Table.java
@@ -2,5 +2,5 @@ package io.gingersnapproject.database.model;
 
 import java.util.List;
 
-public record Table(String name, PrimaryKey primaryKey, List<ForeignKey> foreignKeys) {
+public record Table(String name, List<Column> columns, PrimaryKey primaryKey, List<ForeignKey> foreignKeys, List<UniqueConstraint> uniqueConstraints) {
 }

--- a/manager/src/main/java/io/gingersnapproject/database/model/UniqueConstraint.java
+++ b/manager/src/main/java/io/gingersnapproject/database/model/UniqueConstraint.java
@@ -2,5 +2,5 @@ package io.gingersnapproject.database.model;
 
 import java.util.List;
 
-public record PrimaryKey(String name, List<Column> columns) {
+public record UniqueConstraint(String name, List<Column> columns) {
 }

--- a/manager/src/main/java/io/gingersnapproject/database/vendor/MSSQLVendor.java
+++ b/manager/src/main/java/io/gingersnapproject/database/vendor/MSSQLVendor.java
@@ -1,115 +1,115 @@
-package io.gingersnapproject.database.vendor;
-
-import io.gingersnapproject.database.model.ForeignKey;
-import io.gingersnapproject.database.model.PrimaryKey;
-import io.gingersnapproject.database.model.Table;
-import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.sqlclient.Tuple;
-import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowIterator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static io.gingersnapproject.database.DatabaseHandler.prepareQuery;
-
-public class MSSQLVendor implements Vendor {
-
-    private static final Logger log = LoggerFactory.getLogger(MSSQLVendor.class);
-
-    @Override
-    public Uni<Table> describeTable(Pool pool, String table) {
-        String pkSQL =
-                "SELECT \n" +
-                "     KU.table_name as TABLENAME\n" +
-                "    ,column_name as PRIMARYKEYCOLUMN\n" +
-                "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC \n" +
-                "\n" +
-                "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KU\n" +
-                "    ON TC.CONSTRAINT_TYPE = 'PRIMARY KEY' \n" +
-                "    AND TC.CONSTRAINT_NAME = KU.CONSTRAINT_NAME \n" +
-                "    AND KU.table_name = @P1\n" +
-                "\n" +
-                "ORDER BY \n" +
-                "     KU.TABLE_NAME\n" +
-                "    ,KU.ORDINAL_POSITION\n" +
-                ";";
-        Uni<PrimaryKey> pkUni =
-                prepareQuery(pool, pkSQL)
-                        .execute(Tuple.of(table))
-                        .onFailure().invoke(t -> log.error("Error retrieving primary key from " + table, t))
-                        .map(Vendor::extractPrimaryKey);
-
-        String fkSQL =
-                "SELECT\n" +
-                "    Constraint_Name = C.CONSTRAINT_NAME,\n" +
-                "    PK_Table = PK.TABLE_NAME,\n" +
-                "    FK_Column = CU.COLUMN_NAME,\n" +
-                "    PK_Column = PT.COLUMN_NAME\n" +
-                "FROM\n" +
-                "    INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS C\n" +
-                "INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS FK\n" +
-                "    ON C.CONSTRAINT_NAME = FK.CONSTRAINT_NAME\n" +
-                "INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS PK\n" +
-                "    ON C.UNIQUE_CONSTRAINT_NAME = PK.CONSTRAINT_NAME\n" +
-                "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE CU\n" +
-                "    ON C.CONSTRAINT_NAME = CU.CONSTRAINT_NAME\n" +
-                "INNER JOIN (\n" +
-                "            SELECT\n" +
-                "                i1.TABLE_NAME,\n" +
-                "                i2.COLUMN_NAME\n" +
-                "            FROM\n" +
-                "                INFORMATION_SCHEMA.TABLE_CONSTRAINTS i1\n" +
-                "            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE i2\n" +
-                "                ON i1.CONSTRAINT_NAME = i2.CONSTRAINT_NAME\n" +
-                "            WHERE\n" +
-                "                i1.CONSTRAINT_TYPE = 'PRIMARY KEY'\n" +
-                "           ) PT\n" +
-                "    ON PT.TABLE_NAME = @P1";
-
-        Uni<List<ForeignKey>> fksUni =
-                prepareQuery(pool, fkSQL)
-                        .execute(Tuple.of(table))
-                        .onFailure().invoke(t -> log.error("Error retrieving foreign keys from " + table, t))
-                        .map(rs -> {
-                            if (rs.size() == 0) {
-                                return Collections.emptyList();
-                            }
-                            List<ForeignKey> foreignKeys = new ArrayList<>(2);
-                            String fkName = null;
-                            List<String> columns = new ArrayList<>(2);
-                            String fkTable = null;
-                            List<String> fkColumns = new ArrayList<>(2);
-                            for (RowIterator<Row> i = rs.iterator(); i.hasNext(); ) {
-                                Row row = i.next();
-                                String newFkName = row.getString(0);
-                                if (fkName != null && !newFkName.equals(fkName)) {
-                                    foreignKeys.add(new ForeignKey(fkName, columns, fkTable, fkColumns));
-                                    columns = new ArrayList<>(2);
-                                    fkColumns = new ArrayList<>(2);
-                                }
-                                fkName = newFkName;
-                                fkTable = row.getString(1);
-                                columns.add(row.getString(2));
-                                fkColumns.add(row.getString(3));
-                            }
-                            foreignKeys.add(new ForeignKey(fkName, columns, fkTable, fkColumns));
-                            return foreignKeys;
-                        });
-
-        return Uni.combine().all().unis(pkUni, fksUni).combinedWith((pk, fks) -> new Table(table, pk, fks)).onFailure().recoverWithNull();
-    }
-
-    @Override
-    public String whereClause(List<String> keys) {
-        return IntStream.range(0,keys.size())
-            .mapToObj(index -> String.format("%s = @P%d", keys.get(index), index+1))
-            .collect(Collectors.joining(" AND "));
-    }
-}
+//package io.gingersnapproject.database.vendor;
+//
+//import io.gingersnapproject.database.model.ForeignKey;
+//import io.gingersnapproject.database.model.PrimaryKey;
+//import io.gingersnapproject.database.model.Table;
+//import io.smallrye.mutiny.Uni;
+//import io.vertx.mutiny.sqlclient.Tuple;
+//import io.vertx.sqlclient.Pool;
+//import io.vertx.sqlclient.Row;
+//import io.vertx.sqlclient.RowIterator;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//
+//import java.util.ArrayList;
+//import java.util.Collections;
+//import java.util.List;
+//import java.util.stream.Collectors;
+//import java.util.stream.IntStream;
+//
+//import static io.gingersnapproject.database.DatabaseHandler.prepareQuery;
+//
+//public class MSSQLVendor implements Vendor {
+//
+//    private static final Logger log = LoggerFactory.getLogger(MSSQLVendor.class);
+//
+//    @Override
+//    public Uni<Table> describeTable(Pool pool, String table) {
+//        String pkSQL =
+//                "SELECT \n" +
+//                "     KU.table_name as TABLENAME\n" +
+//                "    ,column_name as PRIMARYKEYCOLUMN\n" +
+//                "FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS TC \n" +
+//                "\n" +
+//                "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KU\n" +
+//                "    ON TC.CONSTRAINT_TYPE = 'PRIMARY KEY' \n" +
+//                "    AND TC.CONSTRAINT_NAME = KU.CONSTRAINT_NAME \n" +
+//                "    AND KU.table_name = @P1\n" +
+//                "\n" +
+//                "ORDER BY \n" +
+//                "     KU.TABLE_NAME\n" +
+//                "    ,KU.ORDINAL_POSITION\n" +
+//                ";";
+//        Uni<PrimaryKey> pkUni =
+//                prepareQuery(pool, pkSQL)
+//                        .execute(Tuple.of(table))
+//                        .onFailure().invoke(t -> log.error("Error retrieving primary key from " + table, t))
+//                        .map(Vendor::extractPrimaryKey);
+//
+//        String fkSQL =
+//                "SELECT\n" +
+//                "    Constraint_Name = C.CONSTRAINT_NAME,\n" +
+//                "    PK_Table = PK.TABLE_NAME,\n" +
+//                "    FK_Column = CU.COLUMN_NAME,\n" +
+//                "    PK_Column = PT.COLUMN_NAME\n" +
+//                "FROM\n" +
+//                "    INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS C\n" +
+//                "INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS FK\n" +
+//                "    ON C.CONSTRAINT_NAME = FK.CONSTRAINT_NAME\n" +
+//                "INNER JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS PK\n" +
+//                "    ON C.UNIQUE_CONSTRAINT_NAME = PK.CONSTRAINT_NAME\n" +
+//                "INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE CU\n" +
+//                "    ON C.CONSTRAINT_NAME = CU.CONSTRAINT_NAME\n" +
+//                "INNER JOIN (\n" +
+//                "            SELECT\n" +
+//                "                i1.TABLE_NAME,\n" +
+//                "                i2.COLUMN_NAME\n" +
+//                "            FROM\n" +
+//                "                INFORMATION_SCHEMA.TABLE_CONSTRAINTS i1\n" +
+//                "            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE i2\n" +
+//                "                ON i1.CONSTRAINT_NAME = i2.CONSTRAINT_NAME\n" +
+//                "            WHERE\n" +
+//                "                i1.CONSTRAINT_TYPE = 'PRIMARY KEY'\n" +
+//                "           ) PT\n" +
+//                "    ON PT.TABLE_NAME = @P1";
+//
+//        Uni<List<ForeignKey>> fksUni =
+//                prepareQuery(pool, fkSQL)
+//                        .execute(Tuple.of(table))
+//                        .onFailure().invoke(t -> log.error("Error retrieving foreign keys from " + table, t))
+//                        .map(rs -> {
+//                            if (rs.size() == 0) {
+//                                return Collections.emptyList();
+//                            }
+//                            List<ForeignKey> foreignKeys = new ArrayList<>(2);
+//                            String fkName = null;
+//                            List<String> columns = new ArrayList<>(2);
+//                            String fkTable = null;
+//                            List<String> fkColumns = new ArrayList<>(2);
+//                            for (RowIterator<Row> i = rs.iterator(); i.hasNext(); ) {
+//                                Row row = i.next();
+//                                String newFkName = row.getString(0);
+//                                if (fkName != null && !newFkName.equals(fkName)) {
+//                                    foreignKeys.add(new ForeignKey(fkName, columns, fkTable, fkColumns));
+//                                    columns = new ArrayList<>(2);
+//                                    fkColumns = new ArrayList<>(2);
+//                                }
+//                                fkName = newFkName;
+//                                fkTable = row.getString(1);
+//                                columns.add(row.getString(2));
+//                                fkColumns.add(row.getString(3));
+//                            }
+//                            foreignKeys.add(new ForeignKey(fkName, columns, fkTable, fkColumns));
+//                            return foreignKeys;
+//                        });
+//
+//        return Uni.combine().all().unis(pkUni, fksUni).combinedWith((pk, fks) -> new Table(table, pk, fks)).onFailure().recoverWithNull();
+//    }
+//
+//    @Override
+//    public String whereClause(List<String> keys) {
+//        return IntStream.range(0,keys.size())
+//            .mapToObj(index -> String.format("%s = @P%d", keys.get(index), index+1))
+//            .collect(Collectors.joining(" AND "));
+//    }
+//}

--- a/manager/src/main/java/io/gingersnapproject/database/vendor/MySQLVendor.java
+++ b/manager/src/main/java/io/gingersnapproject/database/vendor/MySQLVendor.java
@@ -4,9 +4,13 @@ import static io.gingersnapproject.database.DatabaseHandler.prepareQuery;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import io.gingersnapproject.database.model.Column;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,43 +28,90 @@ public class MySQLVendor implements Vendor {
 
    @Override
    public Uni<Table> describeTable(Pool pool, String table) {
-      // Obtain the PK columns
-      Uni<PrimaryKey> pkUni =
-            prepareQuery(pool, "select constraint_name, column_name from information_schema.key_column_usage where table_name = ? and constraint_name in (select constraint_name from information_schema.table_constraints where table_name = ? and constraint_type='PRIMARY KEY') order by ordinal_position")
-                  .execute(Tuple.of(table, table))
-                  .onFailure().invoke(t -> log.error("Error retrieving primary key from " + table, t))
-                  .map(Vendor::extractPrimaryKey);
-      Uni<List<ForeignKey>> fksUni =
-            prepareQuery(pool, "select constraint_name, referenced_table_name, column_name, referenced_column_name from information_schema.key_column_usage where table_name = ? and constraint_name in (select constraint_name from information_schema.table_constraints\n" +
-                  " where table_name = ? and constraint_type='FOREIGN KEY') order by constraint_name, ordinal_position")
-                  .execute(Tuple.of(table, table))
-                  .onFailure().invoke(t -> log.error("Error retrieving foreign keys from " + table, t))
-                  .map(rs -> {
-                     if (rs.size() == 0) {
-                        return Collections.emptyList();
-                     }
-                     List<ForeignKey> foreignKeys = new ArrayList<>(2);
-                     String fkName = null;
-                     List<String> columns = new ArrayList<>(2);
-                     String fkTable = null;
-                     List<String> fkColumns = new ArrayList<>(2);
-                     for (RowIterator<Row> i = rs.iterator(); i.hasNext(); ) {
-                        Row row = i.next();
-                        String newFkName = row.getString(0);
-                        if (fkName != null && !newFkName.equals(fkName)) {
-                           foreignKeys.add(new ForeignKey(fkName, columns, fkTable, fkColumns));
-                           columns = new ArrayList<>(2);
-                           fkColumns = new ArrayList<>(2);
-                        }
-                        fkName = newFkName;
-                        fkTable = row.getString(1);
-                        columns.add(row.getString(2));
-                        fkColumns.add(row.getString(3));
-                     }
-                     foreignKeys.add(new ForeignKey(fkName, columns, fkTable, fkColumns));
-                     return foreignKeys;
-                  });
-      return Uni.combine().all().unis(pkUni, fksUni).combinedWith((pk, fks) -> new Table(table, pk, fks)).onFailure().recoverWithNull();
+       Uni<List<Column>> uni = prepareQuery(pool, "DESC " + table + ";")
+               .execute()
+               .onFailure().invoke(t -> log.error("Error retrieving table description for " + table, t))
+               .map(rs -> {
+                   List<Column> columns = new ArrayList<>();
+                   // Column 1: Field - name of column
+                   // Column 2: Type - type of column
+                   // Column 3: Null - whether column is nullable
+                   // Column 4: Key - what kind of key constraint it may have (e.g primary or unique)
+                   // Column 5: Default - what the default values if ro the column
+                   // Column 6: Extra - additional properties such as auto_increment
+                   for (Row row : rs) {
+                       String columnName = row.getString(0);
+                       String columnType = row.getString(1);
+                       columns.add(new Column(columnName, columnType));
+                   }
+                   return columns;
+               });
+
+       return uni.onItem().transformToUni(columns -> {
+           Map<String, Column> columnMap = columns.stream().collect(Collectors.toMap(c -> c.name().toUpperCase(), Function.identity()));
+           // Obtain the PK columns
+           Uni<PrimaryKey> pkUni =
+                   prepareQuery(pool, "select constraint_name, column_name from information_schema.key_column_usage where table_name = ? and constraint_name in (select constraint_name from information_schema.table_constraints where table_name = ? and constraint_type='PRIMARY KEY') order by ordinal_position")
+                           .execute(Tuple.of(table, table))
+                           .onFailure().invoke(t -> log.error("Error retrieving primary key from " + table, t))
+                           .map(rs -> {
+                               String pkName = null;
+                               List<Column> pkColumns = new ArrayList<>(2);
+                               for (Row row : rs) {
+                                   pkName = row.getString(0);
+                                   String pkColumnName = row.getString(1).toUpperCase();
+                                   Column pkColumn = columnMap.get(pkColumnName);
+                                   if (pkColumn == null) {
+                                       throw new IllegalStateException("PK Column " + pkColumnName + " not found in columns: " + columns);
+                                   }
+                                   pkColumns.add(pkColumn);
+                               }
+                               return new PrimaryKey(pkName, pkColumns);
+                           });
+           Uni<List<ForeignKey>> fksUni =
+                   prepareQuery(pool, "select constraint_name, referenced_table_name, column_name, referenced_column_name from information_schema.key_column_usage where table_name = ? and constraint_name in (select constraint_name from information_schema.table_constraints\n" +
+                           " where table_name = ? and constraint_type='FOREIGN KEY') order by constraint_name, ordinal_position")
+                           .execute(Tuple.of(table, table))
+                           .onFailure().invoke(t -> log.error("Error retrieving foreign keys from " + table, t))
+                           .map(rs -> {
+                               if (rs.size() == 0) {
+                                   return Collections.emptyList();
+                               }
+                               List<ForeignKey> foreignKeys = new ArrayList<>(2);
+                               String fkName = null;
+                               List<Column> fkColumns = new ArrayList<>(2);
+                               String fkTable = null;
+                               List<String> refFkColumns = new ArrayList<>(2);
+                               for (Row row : rs) {
+                                   String newFkName = row.getString(0);
+                                   if (fkName != null && !newFkName.equals(fkName)) {
+                                       foreignKeys.add(new ForeignKey(fkName, fkColumns, fkTable, refFkColumns));
+                                       fkColumns = new ArrayList<>(2);
+                                       refFkColumns = new ArrayList<>(2);
+                                   }
+                                   fkName = newFkName;
+                                   fkTable = row.getString(1);
+
+                                   String fkColumnName = row.getString(2).toUpperCase();
+                                   Column pkColumn = columnMap.get(fkColumnName);
+                                   if (pkColumn == null) {
+                                       throw new IllegalStateException("FK Column " + fkColumnName + " not found in columns: " + columns);
+                                   }
+
+                                   fkColumns.add(pkColumn);
+                                   refFkColumns.add(row.getString(3));
+                               }
+                               foreignKeys.add(new ForeignKey(fkName, fkColumns, fkTable, refFkColumns));
+                               return foreignKeys;
+                           });
+           return Uni.combine().all().unis(pkUni, fksUni)
+                   // TODO: add unique constraints
+                   .combinedWith((pk, fks) -> new Table(table, columns, pk, fks, null))
+                   .onFailure().call(t -> {
+                       log.error("Error encountered while processing table columns", t);
+                       return Uni.createFrom().nullItem();
+                   });
+       });
    }
 
    @Override

--- a/manager/src/main/java/io/gingersnapproject/database/vendor/OracleVendor.java
+++ b/manager/src/main/java/io/gingersnapproject/database/vendor/OracleVendor.java
@@ -1,82 +1,82 @@
-package io.gingersnapproject.database.vendor;
-
-import static io.gingersnapproject.database.DatabaseHandler.prepareQuery;
-
-import java.lang.invoke.MethodHandles;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.gingersnapproject.database.model.ForeignKey;
-import io.gingersnapproject.database.model.PrimaryKey;
-import io.gingersnapproject.database.model.Table;
-import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.sqlclient.Tuple;
-import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.Row;
-
-/**
- * TODO!
- */
-public class OracleVendor implements Vendor {
-
-   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-   private static final String PRIMARY_KEY_QUERY =
-         "SELECT cols.constraint_name, cols.column_name" +
-               " FROM all_constraints cons, all_cons_columns cols" +
-               " WHERE cols.table_name = ?" +
-               " AND cons.constraint_type = 'P'" +
-               " AND cons.constraint_name = cols.constraint_name" +
-               " AND cons.owner = cols.owner" +
-               " ORDER BY cols.position";
-
-   private static final String FOREIGN_KEY_QUERY =
-         "WITH constraint_colum_list as" +
-               " (SELECT owner, table_name, constraint_name, listagg(column_name,',') WITHIN GROUP ( ORDER BY position ) as column_list FROM all_cons_columns GROUP BY owner, table_name, constraint_name )" +
-               " SELECT DISTINCT c1.constraint_name, c2.column_list, c3.table_name, c3.column_list" +
-               " FROM all_constraints c1" +
-               " JOIN constraint_colum_list c2 ON c1.constraint_name=c2.constraint_name and c1.owner=c2.owner" +
-               " JOIN constraint_colum_list c3 ON c1.r_constraint_name=c3.constraint_name AND c1.r_owner=C3.owner" +
-               " WHERE c1.constraint_type = 'R' and c1.table_name = ?";
-
-   @Override
-   public Uni<Table> describeTable(Pool pool, String table) {
-      // Obtain the PK columns
-      Uni<PrimaryKey> pkUni = prepareQuery(pool, PRIMARY_KEY_QUERY)
-            .execute(Tuple.of(table.toUpperCase()))
-            .onFailure().invoke(t -> log.error("Error retrieving primary key from " + table, t))
-            .map(Vendor::extractPrimaryKeyInLowerCase);
-      Uni<List<ForeignKey>> fksUni = prepareQuery(pool, FOREIGN_KEY_QUERY)
-            .execute(Tuple.of(table.toUpperCase()))
-            .onFailure().invoke(t -> log.error("Error retrieving foreign keys from " + table, t))
-            .map(rs -> {
-               List<ForeignKey> foreignKeys = new ArrayList<>(rs.size());
-               for (Row row : rs) {
-                  foreignKeys.add(foreignKeyFromRow(row));
-               }
-               return foreignKeys;
-            });
-      return Uni.combine().all().unis(pkUni, fksUni).combinedWith((pk, fks) -> new Table(table.toLowerCase(), pk, fks));
-   }
-
-   private static ForeignKey foreignKeyFromRow(Row row) {
-      return new ForeignKey(row.getString(0).toLowerCase(),
-            splitColumnList(row.getString(1).toLowerCase()),
-            row.getString(2).toLowerCase(),
-            splitColumnList(row.getString(3).toLowerCase()));
-   }
-
-   private static List<String> splitColumnList(String columns) {
-      return Arrays.asList(columns.split(","));
-   }
-
-   @Override
-   public String whereClause(List<String> keys) {
-      return keys.stream().map(s -> s + " = ?").collect(Collectors.joining(" AND "));
-   }
-}
+//package io.gingersnapproject.database.vendor;
+//
+//import static io.gingersnapproject.database.DatabaseHandler.prepareQuery;
+//
+//import java.lang.invoke.MethodHandles;
+//import java.util.ArrayList;
+//import java.util.Arrays;
+//import java.util.List;
+//import java.util.stream.Collectors;
+//
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//
+//import io.gingersnapproject.database.model.ForeignKey;
+//import io.gingersnapproject.database.model.PrimaryKey;
+//import io.gingersnapproject.database.model.Table;
+//import io.smallrye.mutiny.Uni;
+//import io.vertx.mutiny.sqlclient.Tuple;
+//import io.vertx.sqlclient.Pool;
+//import io.vertx.sqlclient.Row;
+//
+///**
+// * TODO!
+// */
+//public class OracleVendor implements Vendor {
+//
+//   private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+//
+//   private static final String PRIMARY_KEY_QUERY =
+//         "SELECT cols.constraint_name, cols.column_name" +
+//               " FROM all_constraints cons, all_cons_columns cols" +
+//               " WHERE cols.table_name = ?" +
+//               " AND cons.constraint_type = 'P'" +
+//               " AND cons.constraint_name = cols.constraint_name" +
+//               " AND cons.owner = cols.owner" +
+//               " ORDER BY cols.position";
+//
+//   private static final String FOREIGN_KEY_QUERY =
+//         "WITH constraint_colum_list as" +
+//               " (SELECT owner, table_name, constraint_name, listagg(column_name,',') WITHIN GROUP ( ORDER BY position ) as column_list FROM all_cons_columns GROUP BY owner, table_name, constraint_name )" +
+//               " SELECT DISTINCT c1.constraint_name, c2.column_list, c3.table_name, c3.column_list" +
+//               " FROM all_constraints c1" +
+//               " JOIN constraint_colum_list c2 ON c1.constraint_name=c2.constraint_name and c1.owner=c2.owner" +
+//               " JOIN constraint_colum_list c3 ON c1.r_constraint_name=c3.constraint_name AND c1.r_owner=C3.owner" +
+//               " WHERE c1.constraint_type = 'R' and c1.table_name = ?";
+//
+//   @Override
+//   public Uni<Table> describeTable(Pool pool, String table) {
+//      // Obtain the PK columns
+//      Uni<PrimaryKey> pkUni = prepareQuery(pool, PRIMARY_KEY_QUERY)
+//            .execute(Tuple.of(table.toUpperCase()))
+//            .onFailure().invoke(t -> log.error("Error retrieving primary key from " + table, t))
+//            .map(Vendor::extractPrimaryKeyInLowerCase);
+//      Uni<List<ForeignKey>> fksUni = prepareQuery(pool, FOREIGN_KEY_QUERY)
+//            .execute(Tuple.of(table.toUpperCase()))
+//            .onFailure().invoke(t -> log.error("Error retrieving foreign keys from " + table, t))
+//            .map(rs -> {
+//               List<ForeignKey> foreignKeys = new ArrayList<>(rs.size());
+//               for (Row row : rs) {
+//                  foreignKeys.add(foreignKeyFromRow(row));
+//               }
+//               return foreignKeys;
+//            });
+//      return Uni.combine().all().unis(pkUni, fksUni).combinedWith((pk, fks) -> new Table(table.toLowerCase(), pk, fks));
+//   }
+//
+//   private static ForeignKey foreignKeyFromRow(Row row) {
+//      return new ForeignKey(row.getString(0).toLowerCase(),
+//            splitColumnList(row.getString(1).toLowerCase()),
+//            row.getString(2).toLowerCase(),
+//            splitColumnList(row.getString(3).toLowerCase()));
+//   }
+//
+//   private static List<String> splitColumnList(String columns) {
+//      return Arrays.asList(columns.split(","));
+//   }
+//
+//   @Override
+//   public String whereClause(List<String> keys) {
+//      return keys.stream().map(s -> s + " = ?").collect(Collectors.joining(" AND "));
+//   }
+//}

--- a/manager/src/main/java/io/gingersnapproject/database/vendor/PostgreSQLVendor.java
+++ b/manager/src/main/java/io/gingersnapproject/database/vendor/PostgreSQLVendor.java
@@ -1,68 +1,68 @@
-package io.gingersnapproject.database.vendor;
-
-import static io.gingersnapproject.database.DatabaseHandler.prepareQuery;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.gingersnapproject.database.model.ForeignKey;
-import io.gingersnapproject.database.model.PrimaryKey;
-import io.gingersnapproject.database.model.Table;
-import io.smallrye.mutiny.Uni;
-import io.vertx.mutiny.sqlclient.Tuple;
-import io.vertx.sqlclient.Pool;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowIterator;
-
-public class PostgreSQLVendor implements Vendor {
-   private static final Logger log = LoggerFactory.getLogger(PostgreSQLVendor.class);
-
-   @Override
-   public Uni<Table> describeTable(Pool pool, String table) {
-      // Obtain the PK columns
-      Uni<PrimaryKey> pkUni =
-            prepareQuery(pool, "select constraint_name, column_name from information_schema.key_column_usage where table_name = '$1' and constraint_name in (select constraint_name from information_schema.table_constraints where table_name = '$2' and constraint_type='PRIMARY KEY') order by ordinal_position")
-                  .execute(Tuple.of(table, table))
-                  .onFailure().invoke(t -> log.error("Error retrieving primary key from " + table, t))
-                  .map(Vendor::extractPrimaryKey);
-      Uni<List<ForeignKey>> fksUni =
-            prepareQuery(pool, "select kcu.constraint_name, kcu.column_name, ccu.table_name as ref_table, ccu.column_name as ref_column from information_schema.key_column_usage kcu, information_schema.constraint_column_usage ccu where kcu.constraint_name=ccu.constraint_name and kcu.table_name = '$1' and kcu.constraint_name in (select constraint_name from information_schema.table_constraints where table_name = '$2' and constraint_type='FOREIGN KEY') order by kcu.ordinal_position")
-                  .execute(Tuple.of(table, table))
-                  .onFailure().invoke(t -> log.error("Error retrieving foreign keys from " + table, t))
-                  .map(rs -> {
-                     List<ForeignKey> foreignKeys = new ArrayList<>(2);
-                     String fkName = null;
-                     List<String> columns = new ArrayList<>(2);
-                     String fkTable = null;
-                     List<String> fkColumns = new ArrayList<>(2);
-                     for (RowIterator<Row> i = rs.iterator(); i.hasNext(); ) {
-                        Row row = i.next();
-                        String newFkName = row.getString(0);
-                        if (fkName != null && !newFkName.equals(fkName)) {
-                           foreignKeys.add(new ForeignKey(fkName, columns, fkTable, fkColumns));
-                           columns = new ArrayList<>(2);
-                           fkColumns = new ArrayList<>(2);
-                        }
-                        fkName = newFkName;
-                        fkTable = row.getString(1);
-                        columns.add(row.getString(2));
-                        fkColumns.add(row.getString(3));
-                     }
-                     foreignKeys.add(new ForeignKey(fkName, columns, fkTable, fkColumns));
-                     return foreignKeys;
-                  });
-      return Uni.combine().all().unis(pkUni, fksUni).combinedWith((pk, fks) -> new Table(table, pk, fks));
-   }
-
-   @Override
-   public String whereClause(List<String> keys) {
-      return IntStream.range(0, keys.size())
-            .mapToObj(index -> keys.get(index) + " = $" + (index + 1))
-            .collect(Collectors.joining(" AND "));
-   };
-}
+//package io.gingersnapproject.database.vendor;
+//
+//import static io.gingersnapproject.database.DatabaseHandler.prepareQuery;
+//
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.stream.Collectors;
+//import java.util.stream.IntStream;
+//
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+//
+//import io.gingersnapproject.database.model.ForeignKey;
+//import io.gingersnapproject.database.model.PrimaryKey;
+//import io.gingersnapproject.database.model.Table;
+//import io.smallrye.mutiny.Uni;
+//import io.vertx.mutiny.sqlclient.Tuple;
+//import io.vertx.sqlclient.Pool;
+//import io.vertx.sqlclient.Row;
+//import io.vertx.sqlclient.RowIterator;
+//
+//public class PostgreSQLVendor implements Vendor {
+//   private static final Logger log = LoggerFactory.getLogger(PostgreSQLVendor.class);
+//
+//   @Override
+//   public Uni<Table> describeTable(Pool pool, String table) {
+//      // Obtain the PK columns
+//      Uni<PrimaryKey> pkUni =
+//            prepareQuery(pool, "select constraint_name, column_name from information_schema.key_column_usage where table_name = '$1' and constraint_name in (select constraint_name from information_schema.table_constraints where table_name = '$2' and constraint_type='PRIMARY KEY') order by ordinal_position")
+//                  .execute(Tuple.of(table, table))
+//                  .onFailure().invoke(t -> log.error("Error retrieving primary key from " + table, t))
+//                  .map(Vendor::extractPrimaryKey);
+//      Uni<List<ForeignKey>> fksUni =
+//            prepareQuery(pool, "select kcu.constraint_name, kcu.column_name, ccu.table_name as ref_table, ccu.column_name as ref_column from information_schema.key_column_usage kcu, information_schema.constraint_column_usage ccu where kcu.constraint_name=ccu.constraint_name and kcu.table_name = '$1' and kcu.constraint_name in (select constraint_name from information_schema.table_constraints where table_name = '$2' and constraint_type='FOREIGN KEY') order by kcu.ordinal_position")
+//                  .execute(Tuple.of(table, table))
+//                  .onFailure().invoke(t -> log.error("Error retrieving foreign keys from " + table, t))
+//                  .map(rs -> {
+//                     List<ForeignKey> foreignKeys = new ArrayList<>(2);
+//                     String fkName = null;
+//                     List<String> columns = new ArrayList<>(2);
+//                     String fkTable = null;
+//                     List<String> fkColumns = new ArrayList<>(2);
+//                     for (RowIterator<Row> i = rs.iterator(); i.hasNext(); ) {
+//                        Row row = i.next();
+//                        String newFkName = row.getString(0);
+//                        if (fkName != null && !newFkName.equals(fkName)) {
+//                           foreignKeys.add(new ForeignKey(fkName, columns, fkTable, fkColumns));
+//                           columns = new ArrayList<>(2);
+//                           fkColumns = new ArrayList<>(2);
+//                        }
+//                        fkName = newFkName;
+//                        fkTable = row.getString(1);
+//                        columns.add(row.getString(2));
+//                        fkColumns.add(row.getString(3));
+//                     }
+//                     foreignKeys.add(new ForeignKey(fkName, columns, fkTable, fkColumns));
+//                     return foreignKeys;
+//                  });
+//      return Uni.combine().all().unis(pkUni, fksUni).combinedWith((pk, fks) -> new Table(table, pk, fks));
+//   }
+//
+//   @Override
+//   public String whereClause(List<String> keys) {
+//      return IntStream.range(0, keys.size())
+//            .mapToObj(index -> keys.get(index) + " = $" + (index + 1))
+//            .collect(Collectors.joining(" AND "));
+//   };
+//}

--- a/manager/src/main/java/io/gingersnapproject/database/vendor/Vendor.java
+++ b/manager/src/main/java/io/gingersnapproject/database/vendor/Vendor.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.gingersnapproject.database.model.Column;
 import io.gingersnapproject.database.model.PrimaryKey;
 import io.gingersnapproject.database.model.Table;
 import io.smallrye.mutiny.Uni;
@@ -17,17 +18,17 @@ import io.vertx.sqlclient.RowSet;
 public interface Vendor {
    static Vendor fromDbKind(String dbKind) {
       return switch (dbKind.toLowerCase()) {
-         case "postgresql":
-         case "pgsql":
-         case "pg":
-            yield new PostgreSQLVendor();
-         case "mssql":
-            yield new MSSQLVendor();
+//         case "postgresql":
+//         case "pgsql":
+//         case "pg":
+//            yield new PostgreSQLVendor();
+//         case "mssql":
+//            yield new MSSQLVendor();
          case "mysql":
          case "mariadb":
             yield new MySQLVendor();
-         case "oracle":
-            yield new OracleVendor();
+//         case "oracle":
+//            yield new OracleVendor();
          default:
             throw new UnsupportedOperationException();
       };
@@ -37,20 +38,20 @@ public interface Vendor {
 
    static PrimaryKey extractPrimaryKey(RowSet<Row> rows) {
       String pkName = null;
-      List<String> pkColumns = new ArrayList<>(2);
+      List<Column> pkColumns = new ArrayList<>(2);
       for (Row row : rows) {
          pkName = row.getString(0);
-         pkColumns.add(row.getString(1));
+         pkColumns.add(new Column(row.getString(1), "TODO"));
       }
       return new PrimaryKey(pkName, pkColumns);
    }
 
    static PrimaryKey extractPrimaryKeyInLowerCase(RowSet<Row> rows) {
       String pkName = null;
-      List<String> pkColumns = new ArrayList<>(2);
+      List<Column> pkColumns = new ArrayList<>(2);
       for (Row row : rows) {
          pkName = row.getString(0).toLowerCase();
-         pkColumns.add(row.getString(1).toLowerCase());
+         pkColumns.add(new Column(row.getString(1).toLowerCase(), "TODO"));
       }
       return new PrimaryKey(pkName, pkColumns);
    }

--- a/manager/src/main/java/io/gingersnapproject/k8s/CacheRuleInformer.java
+++ b/manager/src/main/java/io/gingersnapproject/k8s/CacheRuleInformer.java
@@ -28,6 +28,7 @@ import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -321,6 +322,16 @@ public class CacheRuleInformer {
                public String table() {
                   return (schemaTable.length == 1) ? schemaTable[0] : schemaTable[1];
                }
+
+               @Override
+               public List<String> keyColumns() {
+                  return eagerRule.getKey().getKeyColumnsList();
+               }
+
+               @Override
+               public List<String> valueColumns() {
+                  return eagerRule.getValue().getValueColumnsList();
+               }
             };
          }
          return connector;
@@ -371,6 +382,7 @@ public class CacheRuleInformer {
                '}';
       }
 
+      // TODO move this logic to DatabaseHandler like wburns PR
       private void buildStatement() {
          StringBuilder sb = new StringBuilder();
          sb.append("SELECT ")

--- a/manager/src/main/resources/application.properties
+++ b/manager/src/main/resources/application.properties
@@ -9,7 +9,7 @@ quarkus.smallrye-openapi.info-license-url=https://www.apache.org/licenses/LICENS
 %dev.quarkus.datasource.db-kind=MYSQL
 %dev.quarkus.datasource.username=gingersnap_user
 %dev.quarkus.datasource.password=password
-%dev.quarkus.datasource.reactive.url=mysql://localhost:3306/debezium
+%dev.quarkus.datasource.reactive.url=mysql://localhost:3306/airports
 
 %dev.gingersnap.lazy-rule.us-east.key-type=TEXT
 %dev.gingersnap.lazy-rule.us-east.plain-separator=:
@@ -19,3 +19,44 @@ quarkus.devservices.enabled=false
 quarkus.elasticsearch.health.enabled=false
 
 quarkus.grpc.server.use-separate-server=false
+
+
+gingersnap.eager-rule.flight.connector.schema=airports
+gingersnap.eager-rule.flight.connector.table=Flight
+gingersnap.eager-rule.flight.connector.key-columns=code
+gingersnap.eager-rule.flight.key-type=TEXT
+gingersnap.eager-rule.flight.plain-separator=:
+gingersnap.eager-rule.flight.select-statement=select * from Flight where code = ?
+gingersnap.eager-rule.flight.query-enabled=false
+
+gingersnap.eager-rule.airport.connector.schema=airports
+gingersnap.eager-rule.airport.connector.table=Airport
+gingersnap.eager-rule.airport.connector.key-columns=id
+gingersnap.eager-rule.airport.key-type=TEXT
+gingersnap.eager-rule.airport.plain-separator=:
+gingersnap.eager-rule.airport.select-statement=select * from Airport where id = ?
+gingersnap.eager-rule.airport.query-enabled=false
+
+gingersnap.eager-rule.aircraft.connector.schema=airports
+gingersnap.eager-rule.aircraft.connector.table=Aircraft
+gingersnap.eager-rule.aircraft.connector.key-columns=id
+gingersnap.eager-rule.aircraft.key-type=TEXT
+gingersnap.eager-rule.aircraft.plain-separator=:
+gingersnap.eager-rule.aircraft.select-statement=select * from Aircraft where id = ?
+gingersnap.eager-rule.aircraft.query-enabled=false
+
+gingersnap.eager-rule.airline.connector.schema=airports
+gingersnap.eager-rule.airline.connector.table=Airline
+gingersnap.eager-rule.airline.connector.key-columns=id
+gingersnap.eager-rule.airline.key-type=TEXT
+gingersnap.eager-rule.airline.plain-separator=:
+gingersnap.eager-rule.airline.select-statement=select * from Airline where id = ?
+gingersnap.eager-rule.airline.query-enabled=false
+
+gingersnap.eager-rule.country.connector.schema=airports
+gingersnap.eager-rule.country.connector.table=Country
+gingersnap.eager-rule.country.connector.key-columns=id
+gingersnap.eager-rule.country.key-type=TEXT
+gingersnap.eager-rule.country.plain-separator=:
+gingersnap.eager-rule.country.select-statement=select * from Country where id = ?
+gingersnap.eager-rule.country.query-enabled=false

--- a/manager/src/test/java/io/gingersnapproject/GraphQLTest.java
+++ b/manager/src/test/java/io/gingersnapproject/GraphQLTest.java
@@ -1,0 +1,19 @@
+package io.gingersnapproject;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+@QuarkusTest
+public class GraphQLTest {
+
+    @Inject
+    Graph graphql;
+
+    @Test
+    public void testValueWithNoForeignKey() {
+        graphql.exec("{hello}");
+//        given().when().body("{hello}").post("/rules/graphql").then().body(not(containsString("British Airways")));
+    }
+}

--- a/schema.ql
+++ b/schema.ql
@@ -1,0 +1,99 @@
+query IntrospectionQuery {
+  __schema {
+    queryType {
+      name
+    }
+    mutationType {
+      name
+    }
+    subscriptionType {
+      name
+    }
+    types {
+      ...FullType
+    }
+    directives {
+      name
+      description
+      locations
+      args {
+        ...InputValue
+      }
+    }
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  description
+  fields(includeDeprecated: true) {
+    name
+    description
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    description
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  description
+  type {
+    ...TypeRef
+  }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
A very rough and ready branch adding GraphQL support.

-  A GraphQL Type is automatically created for each EagerCacheRules
    * All table columns currently defined as fields, but this should only be does explicitly defined as the value columns
    * FK fields reference GraphQL Type created for the corresponding EagerCacheRule
- A query is created for each EagerCacheRule, using the rule name as an identifier and accepting the defined key-column(s) as arguments to lookup an entry.
    * Query returns the cache entry associated with the provided key
    * The query request must explicitly define all fields to be returned
    
- Users submit queries to `/graphql` as GET or POST requests
    * GET `/graphql?query=`
    * POST `/graphql` with body containing GraphQL query string

# Example
Using the https://github.com/gingersnap-project/gingersnap-demo-flights dataset as an example, the following are possible:

Flights with "aircraft" and "airline" FKs partially expanded to only include the specified fields, with fields added/removed from the payload reflected in the response.

1. Request
```
 curl -X POST --data-binary @flight.ql "http://localhost:8080/graphql"
```

`flight.ql`
```
{
    flight(code: "8R6768-2-A"){
        id
        code
        aircraft_id{
            shortDescription
        }
        airline_id{
            publicName
        }
        destination_id{
            name
            city
            country_id{
                name
            }
        }
    }
}

```
2. Response
```
{
  "data" : {
    "flight" : {
      "id" : "8332",
      "code" : "8R6768-2-A",
      "aircraft_id" : {
        "shortDescription" : "EMB 145"
      },
      "airline_id" : {
        "publicName" : "Amelia"
      },
      "destination_id" : {
        "name" : "Strasbourg",
        "city" : "Strasbourg",
        "country_id" : {
          "name" : "France"
        }
      }
    }
  },
  "errors" : null
}
```